### PR TITLE
Switch Encryption Algorithm from AES-CBC to AES-GCM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26,6 +36,20 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
 ]
 
 [[package]]
@@ -129,15 +153,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
-name = "cbc"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
-dependencies = [
- "cipher",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,7 +225,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -383,6 +408,16 @@ dependencies = [
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -867,6 +902,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl"
 version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,6 +1027,18 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1472,12 +1525,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tas_kbm_ctl"
+name = "tas_agent"
 version = "0.1.0"
 dependencies = [
  "aes",
+ "aes-gcm",
  "base64",
- "cbc",
  "cipher",
  "dotenv",
  "hex",
@@ -1619,6 +1672,16 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ rsa = { version = "0.9.8", features = ["sha2"] }
 rand = "~0.8"
 aes = "0.8.4"
 cipher = { version = "0.4.4", features = ["block-padding", "alloc"] }
-cbc = "0.1.2"
 pretty-hex = "0.4.1"
 serde = { version = "1.0.219", features = ["derive", "serde_derive"] }
+aes-gcm = "0.10.3"
 
 [dev-dependencies]
 mockito = "0.31"

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,9 +131,8 @@ async fn main() {
         Err(err) => {
             eprintln!("JSON Deserialize Error: {}", err);
             std::process::exit(1);
-        }       
+        }
     };
-
 
     // Unwrap the secret key using the wrapping key
     debug_println!(debug, "Unwrapping secret key...");
@@ -149,7 +148,7 @@ async fn main() {
     // Decrypt the secret payload using the unwrapped AES key
     debug_println!(debug, "Decrypting secret payload...");
     let decrypted_payload =
-        match decrypt_secret_with_aes_key(&aes_key, &secret.iv, &mut secret.blob) {
+        match decrypt_secret_with_aes_key(&aes_key, &secret.iv, &mut secret.blob, &secret.tag) {
             Ok(decrypted_payload) => decrypted_payload,
             Err(err) => {
                 eprintln!("Crypto Decrypt Error: {}", err);
@@ -157,6 +156,4 @@ async fn main() {
             }
         };
     println!("{}", String::from_utf8_lossy(&decrypted_payload));
-
-
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -16,6 +16,8 @@ pub struct SecretsPayload {
     pub blob: Vec<u8>,
     #[serde(deserialize_with = "deserialize_base64")]
     pub iv: Vec<u8>,
+    #[serde(deserialize_with = "deserialize_base64")]
+    pub tag: Vec<u8>,
 }
 
 fn deserialize_base64<'de, D, T>(d: D) -> Result<T, D::Error>


### PR DESCRIPTION
Replace the AES-CBC encryption algorithm, which is considered hard to use correctly and prone to implementation issues, with AES-GCM, a more secure and robust alternative.

This is a breaking change and requires compatibility with the updated TAs server. Ensure the server-side implementation aligns with the new encryption standard.