### PR TITLE
Fix pre-commit GitHub Actions workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,6 +13,6 @@ jobs:
     - uses: actions/setup-python@v3
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        rust-version: stable
-        components: rustfmt clippy
+        toolchain: stable
+        components: rustfmt, clippy
     - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
Address `Warning: Unexpected input(s) 'rust-version' ...` from actions-rust-lang/setup-rust-toolchain@v1 by updating configuration.