### PR TITLE
Bind RSA public key to TEE attestation report

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,16 +18,19 @@ jobs:
         components: rustfmt, clippy
     
     - name: Build debug image 
-      run: cargo build
+      run: cargo build --all-features
 
     - name: Build release image 
-      run: cargo build --release
+      run: cargo build --release --all-features
 
     - name: Run tests on debug image
-      run: cargo test
+      run: cargo test --all-features
 
     - name: Run tests on release image
-      run: cargo test --release
+      run: cargo test --release --all-features
+      
+    - name: Build docs
+      run: cargo doc --no-deps --all-features
 
     - name: Build via script
       run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2031,6 +2031,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "tokio",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ tempfile = "3.6"
 base64 = "0.21"
 hex = "0.4"
 rsa = { version = "0.9.8", features = ["sha2"] }
+sha2 = "0.10"
 # 0.8 required by rsa
 rand = "~0.8"
 aes = "0.8.4"
@@ -26,6 +27,9 @@ chrono = "0.4.43"
 reqwest-middleware = "0.2"
 reqwest-retry = "0.3"
 retry-policies = "0.2"
+
+[features]
+gpu-attestation = []
 
 [dev-dependencies]
 mockito = "1.7"

--- a/README.md
+++ b/README.md
@@ -2,11 +2,32 @@
 
 ## Build Instructions
 
-To build the application, run the following command:
+### CPU-Only Attestation (Default)
+
+The default build includes CPU TEE attestation (AMD SEV-SNP / Intel TDX) with
+public-key binding. This produces the smallest binary, suitable for
+resource-constrained environments such as pre-boot attestation from an initrd.
 
 ```bash
-cargo build
+cargo build --release
 ```
+
+### With GPU Attestation Support
+
+To include GPU attestation support (composable CPU + GPU attestation), enable the
+`gpu-attestation` feature:
+
+```bash
+cargo build --release --features gpu-attestation
+```
+
+> **Note:** GPU attestation is currently a stub and not yet implemented. The
+> `GpuEvidenceProvider` trait and detection framework are in place, but no
+> concrete GPU provider (e.g. NVIDIA) is functional yet. Enabling the feature
+> adds the composable attestation code path but GPU evidence collection will
+> fail at runtime until a provider is implemented.
+
+### Package Build
 
 To build a package for installation (e.g. in /opt/tas), run the following command:
 
@@ -20,6 +41,12 @@ Copy the .tgz file generated to the target VM's /opt/tas directory.
 ## Unit Tests
 
 Unit tests are run via the `cargo test` command.
+
+To run tests including GPU attestation tests:
+
+```bash
+cargo test --features gpu-attestation
+```
 
 ## Execution Instructions
 
@@ -50,6 +77,10 @@ key_id = "..."
 
 # Maximum backoff time in seconds between retries (default: 30)
 # retry_max_backoff_secs = 30
+
+# GPU attestation mode: "auto" or "disabled" (default: "auto")
+# Requires the gpu-attestation feature to be enabled at build time
+# gpu_attestation = "auto"
 ```
 
 If using TLS, ensure that `server_uri` specifies `https`.
@@ -67,6 +98,8 @@ If using TLS, ensure that `server_uri` specifies `https`.
 | `--max-retries <N>` | Maximum number of retry attempts for HTTP requests (default: 3) |
 | `--retry-min-backoff-secs <SECS>` | Minimum backoff time in seconds between retries (default: 1) |
 | `--retry-max-backoff-secs <SECS>` | Maximum backoff time in seconds between retries (default: 30) |
+| `--no-key-binding` | Disable public-key binding in TEE report data (for legacy TAS servers) |
+| `--gpu-attestation <MODE>` | GPU attestation mode: `auto` (default) or `disabled` (requires `gpu-attestation` feature) |
 
 ### Running
 

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -16,6 +16,7 @@ use aes_gcm::{
     Aes256Gcm, Nonce,
 };
 
+use sha2::{Digest, Sha512};
 use std::error::Error;
 
 //TODO: Add own error type, instead of using Box<dyn Error>
@@ -65,7 +66,7 @@ impl RsaKey {
     }
 
     /// Converts public key to DER format
-    fn public_key_to_der(&self) -> Result<Vec<u8>, Box<dyn Error>> {
+    pub fn public_key_to_der(&self) -> Result<Vec<u8>, Box<dyn Error>> {
         let der = self
             .public_key
             .to_pkcs1_der()
@@ -156,6 +157,41 @@ pub fn encrypt_secret_with_aes_key(
     Ok((plaintext.to_vec(), tag.to_vec()))
 }
 
+/// Computes SHA-512(nonce || pubkey_der) for CPU-only key binding.
+/// Returns raw 64-byte hash that fits exactly in REPORT_DATA (SEV-SNP / TDX).
+pub fn compute_report_data_binding(nonce: &[u8], pubkey_der: &[u8]) -> Vec<u8> {
+    let mut hasher = Sha512::new();
+    hasher.update(nonce);
+    hasher.update(pubkey_der);
+    hasher.finalize().to_vec()
+}
+
+#[cfg(feature = "gpu-attestation")]
+/// Computes SHA-512(nonce || pubkey_der || gpu_hashes) for composable attestation.
+/// `gpu_hashes` is the pre-concatenated SHA-512 hashes of each GPU's evidence,
+/// ordered by device index: SHA512(gpu0) || SHA512(gpu1) || ...
+/// Returns raw 64-byte hash.
+pub fn compute_report_data_binding_with_gpu(
+    nonce: &[u8],
+    pubkey_der: &[u8],
+    gpu_hashes: &[u8],
+) -> Vec<u8> {
+    let mut hasher = Sha512::new();
+    hasher.update(nonce);
+    hasher.update(pubkey_der);
+    hasher.update(gpu_hashes);
+    hasher.finalize().to_vec()
+}
+
+#[cfg(feature = "gpu-attestation")]
+/// Computes SHA-512 of a single GPU's raw attestation evidence.
+/// Returns raw 64-byte hash. Called once per GPU before concatenation.
+pub fn hash_gpu_evidence(raw_evidence: &[u8]) -> Vec<u8> {
+    let mut hasher = Sha512::new();
+    hasher.update(raw_evidence);
+    hasher.finalize().to_vec()
+}
+
 //add tests
 #[cfg(test)]
 mod tests {
@@ -171,6 +207,86 @@ mod tests {
     }
 
     #[test]
+    fn test_compute_report_data_binding_length() {
+        let nonce = b"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        let rsa_key = generate_wrapping_key().unwrap();
+        let pubkey_der = rsa_key.public_key_to_der().unwrap();
+        let binding = compute_report_data_binding(nonce, &pubkey_der);
+        assert_eq!(
+            binding.len(),
+            64,
+            "SHA-512 binding must be exactly 64 bytes"
+        );
+    }
+
+    #[test]
+    fn test_compute_report_data_binding_deterministic() {
+        let nonce = b"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        let rsa_key = generate_wrapping_key().unwrap();
+        let pubkey_der = rsa_key.public_key_to_der().unwrap();
+        let binding1 = compute_report_data_binding(nonce, &pubkey_der);
+        let binding2 = compute_report_data_binding(nonce, &pubkey_der);
+        assert_eq!(
+            binding1, binding2,
+            "Same inputs must produce the same binding"
+        );
+    }
+
+    #[test]
+    fn test_compute_report_data_binding_different_keys() {
+        let nonce = b"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        let key1 = generate_wrapping_key().unwrap();
+        let key2 = generate_wrapping_key().unwrap();
+        let der1 = key1.public_key_to_der().unwrap();
+        let der2 = key2.public_key_to_der().unwrap();
+        let binding1 = compute_report_data_binding(nonce, &der1);
+        let binding2 = compute_report_data_binding(nonce, &der2);
+        assert_ne!(
+            binding1, binding2,
+            "Different keys must produce different bindings"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "gpu-attestation")]
+    fn test_compute_report_data_binding_with_gpu() {
+        let nonce = b"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        let rsa_key = generate_wrapping_key().unwrap();
+        let pubkey_der = rsa_key.public_key_to_der().unwrap();
+        let gpu0_evidence = b"gpu0_attestation_report_bytes";
+        let gpu1_evidence = b"gpu1_attestation_report_bytes";
+        let gpu0_hash = hash_gpu_evidence(gpu0_evidence);
+        let gpu1_hash = hash_gpu_evidence(gpu1_evidence);
+        let mut gpu_combined = gpu0_hash.clone();
+        gpu_combined.extend_from_slice(&gpu1_hash);
+        let binding = compute_report_data_binding_with_gpu(nonce, &pubkey_der, &gpu_combined);
+        assert_eq!(binding.len(), 64, "Composable binding must be 64 bytes");
+    }
+
+    #[test]
+    #[cfg(feature = "gpu-attestation")]
+    fn test_hash_gpu_evidence_length() {
+        let evidence = b"some_gpu_attestation_evidence";
+        let hash = hash_gpu_evidence(evidence);
+        assert_eq!(hash.len(), 64, "GPU evidence hash must be 64 bytes");
+    }
+
+    #[test]
+    #[cfg(feature = "gpu-attestation")]
+    fn test_gpu_binding_changes_cpu_hash() {
+        let nonce = b"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        let rsa_key = generate_wrapping_key().unwrap();
+        let pubkey_der = rsa_key.public_key_to_der().unwrap();
+        let cpu_only = compute_report_data_binding(nonce, &pubkey_der);
+        let gpu_hash = hash_gpu_evidence(b"gpu_evidence");
+        let with_gpu = compute_report_data_binding_with_gpu(nonce, &pubkey_der, &gpu_hash);
+        assert_ne!(
+            cpu_only, with_gpu,
+            "Adding GPU evidence must change the CPU binding"
+        );
+    }
+
+    #[test]
     fn test_aes_decryption() {
         let aes_key = [0u8; 32]; // 256-bit key
         let iv = [0u8; 12]; // 96-bit IV (nonce) for AES-GCM
@@ -180,5 +296,119 @@ mod tests {
         let decrypted_data =
             decrypt_secret_with_aes_key(&aes_key, &iv, &mut ciphertext, &tag).unwrap();
         assert_eq!(b"Hello, world!".to_vec(), decrypted_data);
+    }
+
+    // --- public_key_to_der tests ---
+
+    #[test]
+    fn test_public_key_to_der_returns_valid_der() {
+        let rsa_key = generate_wrapping_key().unwrap();
+        let der = rsa_key.public_key_to_der().unwrap();
+        // DER-encoded RSA public keys start with 0x30 (SEQUENCE tag)
+        assert_eq!(der[0], 0x30, "DER encoding must start with SEQUENCE tag");
+    }
+
+    // --- public_key_to_base64 tests ---
+
+    #[test]
+    fn test_public_key_to_base64_valid() {
+        let rsa_key = generate_wrapping_key().unwrap();
+        let b64 = rsa_key.public_key_to_base64().unwrap();
+        // Must be valid base64 that decodes to the same DER
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(&b64)
+            .unwrap();
+        let der = rsa_key.public_key_to_der().unwrap();
+        assert_eq!(decoded, der);
+    }
+
+    // --- unwrap_key roundtrip test ---
+
+    #[test]
+    fn test_unwrap_key_roundtrip() {
+        let rsa_key = generate_wrapping_key().unwrap();
+        let aes_key = b"0123456789abcdef0123456789abcdef"; // 32-byte AES key
+        let encrypted = rsa_key.encrypt(aes_key).unwrap();
+        let unwrapped = rsa_key.unwrap_key(&encrypted).unwrap();
+        assert_eq!(unwrapped, aes_key.to_vec());
+    }
+
+    // --- generate_key_pair with different sizes ---
+
+    #[test]
+    fn test_generate_key_pair_invalid_size() {
+        let result = generate_key_pair(1024);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("2048") || err.contains("3072") || err.contains("4096"));
+    }
+
+    #[test]
+    fn test_generate_key_pair_2048() {
+        let result = generate_key_pair(2048);
+        assert!(result.is_ok());
+    }
+
+    // --- AES validation tests ---
+
+    #[test]
+    fn test_aes_decrypt_wrong_key_length() {
+        let bad_key = [0u8; 16]; // 128-bit, should be 256-bit
+        let iv = [0u8; 12];
+        let mut ciphertext = vec![0u8; 16];
+        let tag = [0u8; 16];
+        let result = decrypt_secret_with_aes_key(&bad_key, &iv, &mut ciphertext, &tag);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("32 bytes"));
+    }
+
+    #[test]
+    fn test_aes_decrypt_wrong_iv_length() {
+        let key = [0u8; 32];
+        let bad_iv = [0u8; 16]; // 128-bit, should be 96-bit
+        let mut ciphertext = vec![0u8; 16];
+        let tag = [0u8; 16];
+        let result = decrypt_secret_with_aes_key(&key, &bad_iv, &mut ciphertext, &tag);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_aes_encrypt_wrong_key_length() {
+        let bad_key = [0u8; 16];
+        let iv = [0u8; 12];
+        let mut plaintext = b"test data".to_vec();
+        let result = encrypt_secret_with_aes_key(&bad_key, &iv, &mut plaintext);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("32 bytes"));
+    }
+
+    #[test]
+    fn test_aes_encrypt_wrong_iv_length() {
+        let key = [0u8; 32];
+        let bad_iv = [0u8; 16];
+        let mut plaintext = b"test data".to_vec();
+        let result = encrypt_secret_with_aes_key(&key, &bad_iv, &mut plaintext);
+        assert!(result.is_err());
+    }
+
+    // --- compute_report_data_binding edge cases ---
+
+    #[test]
+    fn test_binding_different_nonces_produce_different_hashes() {
+        let rsa_key = generate_wrapping_key().unwrap();
+        let pubkey_der = rsa_key.public_key_to_der().unwrap();
+        let nonce1 = b"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        let nonce2 = b"fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
+        let binding1 = compute_report_data_binding(nonce1, &pubkey_der);
+        let binding2 = compute_report_data_binding(nonce2, &pubkey_der);
+        assert_ne!(binding1, binding2);
+    }
+
+    #[test]
+    fn test_binding_empty_nonce() {
+        let rsa_key = generate_wrapping_key().unwrap();
+        let pubkey_der = rsa_key.public_key_to_der().unwrap();
+        let binding = compute_report_data_binding(b"", &pubkey_der);
+        assert_eq!(binding.len(), 64);
     }
 }

--- a/src/gpu_evidence.rs
+++ b/src/gpu_evidence.rs
@@ -1,0 +1,180 @@
+// TEE Attestation Service Agent
+//
+// Copyright 2026 Hewlett Packard Enterprise Development LP.
+// SPDX-License-Identifier: MIT
+//
+// GPU TEE evidence gathering — pluggable provider trait and detection.
+
+use log::debug;
+use serde::Serialize;
+use std::error::Error;
+
+/// A single GPU's attestation evidence entry, sent to the TAS server.
+#[derive(Debug, Clone, Serialize)]
+pub struct GpuEvidenceEntry {
+    /// GPU TEE type identifier (e.g. "nvidia-gpu-h100")
+    #[serde(rename = "tee-type")]
+    pub tee_type: String,
+    /// Device index for deterministic ordering (0, 1, 2, …)
+    #[serde(rename = "device-index")]
+    pub device_index: u32,
+    /// Base64-encoded GPU attestation report
+    #[serde(rename = "tee-evidence")]
+    pub tee_evidence: String,
+}
+
+/// Trait for pluggable GPU attestation evidence providers.
+///
+/// Each implementation represents a single GPU device capable of producing
+/// attestation evidence.  Multiple instances (one per physical device) are
+/// returned by [`detect_gpu_providers`].
+#[allow(dead_code)]
+pub trait GpuEvidenceProvider {
+    /// Human-readable provider name (e.g. "nvidia-h100")
+    fn provider_name(&self) -> &str;
+
+    /// Device index — used for deterministic ordering of GPU evidence.
+    fn device_id(&self) -> u32;
+
+    /// Collect attestation evidence from this GPU.
+    ///
+    /// `nonce` is the raw TAS nonce (same value the CPU would receive).
+    /// GPU report_data uses the raw nonce — no key binding on the GPU side
+    /// (CPU binding covers the GPU evidence via the hash chain).
+    fn get_evidence(&self, nonce: &str) -> Result<GpuEvidenceEntry, Box<dyn Error>>;
+}
+
+// ---------------------------------------------------------------------------
+// Placeholder NVIDIA GPU provider (skeleton)
+// ---------------------------------------------------------------------------
+
+/// Skeleton provider for NVIDIA GPU TEE attestation.
+///
+/// Replace the body of `get_evidence` with the actual NVIDIA Attestation SDK
+/// or local-verifier call when the SDK is available.
+#[allow(dead_code)]
+pub struct NvidiaGpuProvider {
+    device_index: u32,
+}
+
+#[allow(dead_code)]
+impl NvidiaGpuProvider {
+    pub fn new(device_index: u32) -> Self {
+        Self { device_index }
+    }
+}
+
+impl GpuEvidenceProvider for NvidiaGpuProvider {
+    fn provider_name(&self) -> &str {
+        "nvidia-gpu"
+    }
+
+    fn device_id(&self) -> u32 {
+        self.device_index
+    }
+
+    fn get_evidence(&self, _nonce: &str) -> Result<GpuEvidenceEntry, Box<dyn Error>> {
+        // TODO: integrate with NVIDIA Attestation SDK / nvml / device file
+        Err(format!(
+            "NVIDIA GPU attestation not yet implemented for device {}",
+            self.device_index
+        )
+        .into())
+    }
+}
+
+/// Detect all available GPU TEE devices and return one provider per device,
+/// sorted by device index.
+///
+/// Returns an empty Vec when no GPU TEE hardware is found (the CPU-only
+/// binding path will be used).
+pub fn detect_gpu_providers() -> Vec<Box<dyn GpuEvidenceProvider>> {
+    let mut providers: Vec<Box<dyn GpuEvidenceProvider>> = Vec::new();
+
+    // --- NVIDIA detection (placeholder) ---
+    // In production this would enumerate /dev/nvidia* or use nvml to find
+    // GPU TEE–capable devices.  For now we do not auto-detect: callers can
+    // manually construct NvidiaGpuProvider instances when needed.
+    debug!("GPU provider detection: no GPU TEE devices found (placeholder)");
+
+    providers.sort_by_key(|p| p.device_id());
+    providers
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- NvidiaGpuProvider tests ---
+
+    #[test]
+    fn test_nvidia_provider_name() {
+        let provider = NvidiaGpuProvider::new(0);
+        assert_eq!(provider.provider_name(), "nvidia-gpu");
+    }
+
+    #[test]
+    fn test_nvidia_device_id() {
+        let provider = NvidiaGpuProvider::new(5);
+        assert_eq!(provider.device_id(), 5);
+    }
+
+    #[test]
+    fn test_nvidia_get_evidence_returns_error() {
+        let provider = NvidiaGpuProvider::new(2);
+        let result = provider.get_evidence("some_nonce");
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("not yet implemented"));
+        assert!(err.contains("device 2"));
+    }
+
+    // --- detect_gpu_providers tests ---
+
+    #[test]
+    fn test_detect_gpu_providers_returns_empty() {
+        let providers = detect_gpu_providers();
+        assert!(providers.is_empty());
+    }
+
+    // --- GpuEvidenceEntry serialization tests ---
+
+    #[test]
+    fn test_gpu_evidence_entry_serialization() {
+        let entry = GpuEvidenceEntry {
+            tee_type: "nvidia-gpu-h100".to_string(),
+            device_index: 0,
+            tee_evidence: "base64evidence==".to_string(),
+        };
+        let json = serde_json::to_value(&entry).unwrap();
+        // Verify serde rename attributes
+        assert_eq!(json["tee-type"], "nvidia-gpu-h100");
+        assert_eq!(json["device-index"], 0);
+        assert_eq!(json["tee-evidence"], "base64evidence==");
+        // Original field names should NOT appear
+        assert!(json.get("tee_type").is_none());
+        assert!(json.get("device_index").is_none());
+        assert!(json.get("tee_evidence").is_none());
+    }
+
+    #[test]
+    fn test_gpu_evidence_entry_serialization_multiple() {
+        let entries = vec![
+            GpuEvidenceEntry {
+                tee_type: "nvidia-gpu".to_string(),
+                device_index: 0,
+                tee_evidence: "ev0".to_string(),
+            },
+            GpuEvidenceEntry {
+                tee_type: "nvidia-gpu".to_string(),
+                device_index: 1,
+                tee_evidence: "ev1".to_string(),
+            },
+        ];
+        let json = serde_json::to_value(&entries).unwrap();
+        let arr = json.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["device-index"], 0);
+        assert_eq!(arr[1]["device-index"], 1);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 // TEE Attestation Service Agent
 //
-// Copyright 2025 Hewlett Packard Enterprise Development LP.
+// Copyright 2025 -2026 Hewlett Packard Enterprise Development LP.
 // SPDX-License-Identifier: MIT
 //
 // This application interacts via a REST API with the TEE Attestation Service Key Broker Module.
@@ -20,14 +20,62 @@ use std::path::PathBuf;
 
 // Import the `tee_get_evidence` function from the `tee_evidence` module
 mod crypto;
+#[cfg(feature = "gpu-attestation")]
+mod gpu_evidence;
 mod tas_api;
 mod tee_evidence;
 mod utils;
 use anyhow::{anyhow, Context, Result};
 use clap::Parser;
 use serde::Deserialize;
+use std::fmt;
 
-use crypto::{decrypt_secret_with_aes_key, generate_wrapping_key};
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+#[allow(dead_code)]
+enum GpuAttestationMode {
+    Auto,
+    Disabled,
+}
+
+impl fmt::Display for GpuAttestationMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Auto => write!(f, "auto"),
+            Self::Disabled => write!(f, "disabled"),
+        }
+    }
+}
+
+/// Resolve GPU attestation mode from CLI and config values.
+/// CLI takes priority; config is the fallback; default is `Auto`.
+fn resolve_gpu_attestation_mode(
+    #[cfg(feature = "gpu-attestation")] cli_value: GpuAttestationMode,
+    #[cfg(feature = "gpu-attestation")] cfg_value: Option<&str>,
+) -> GpuAttestationMode {
+    #[cfg(not(feature = "gpu-attestation"))]
+    return GpuAttestationMode::Disabled;
+
+    #[cfg(feature = "gpu-attestation")]
+    {
+        // CLI explicitly set (not the default) — use it directly
+        if cli_value != GpuAttestationMode::Auto {
+            return cli_value;
+        }
+        // Fall back to config file value
+        match cfg_value {
+            Some("disabled") => GpuAttestationMode::Disabled,
+            _ => GpuAttestationMode::Auto,
+        }
+    }
+}
+
+#[cfg(feature = "gpu-attestation")]
+use base64::{engine::general_purpose, Engine};
+use crypto::{compute_report_data_binding, decrypt_secret_with_aes_key, generate_wrapping_key};
+#[cfg(feature = "gpu-attestation")]
+use crypto::{compute_report_data_binding_with_gpu, hash_gpu_evidence};
+#[cfg(feature = "gpu-attestation")]
+use gpu_evidence::detect_gpu_providers;
 use tas_api::{tas_get_nonce, tas_get_secret_key, tas_get_version, RetryConfig};
 use tee_evidence::tee_get_evidence;
 use utils::SecretsPayload;
@@ -87,6 +135,11 @@ struct Cli {
     /// Maximum backoff time in seconds between retries (default: 30)
     #[arg(long, value_name = "SECS")]
     retry_max_backoff_secs: Option<u64>,
+
+    /// GPU attestation mode: auto (default) or disabled
+    #[cfg(feature = "gpu-attestation")]
+    #[arg(long, value_enum, default_value_t = GpuAttestationMode::Auto)]
+    gpu_attestation: GpuAttestationMode,
 }
 
 #[derive(Deserialize, Default)]
@@ -98,6 +151,9 @@ struct Config {
     max_retries: Option<u32>,
     retry_min_backoff_secs: Option<u64>,
     retry_max_backoff_secs: Option<u64>,
+    /// GPU attestation mode: "auto", "disabled" (default: "auto")
+    #[cfg(feature = "gpu-attestation")]
+    gpu_attestation: Option<String>,
 }
 
 fn load_config(path: Option<PathBuf>) -> Result<Config> {
@@ -224,8 +280,103 @@ async fn main() {
         }
     };
 
-    // Generate the TEE evidence and get the TEE type using the nonce
-    let (tee_evidence, tee_type) = match tee_get_evidence(&nonce) {
+    // Key binding is always enabled — the RSA public key is bound into
+    // the TEE report_data via SHA-512(nonce || pubkey_der [|| gpu_hashes]).
+    let key_binding_enabled = true;
+    let gpu_attestation_mode = resolve_gpu_attestation_mode(
+        #[cfg(feature = "gpu-attestation")]
+        cli.gpu_attestation,
+        #[cfg(feature = "gpu-attestation")]
+        cfg.gpu_attestation.as_deref(),
+    );
+
+    debug!(
+        "Key binding: {}, GPU attestation: {}",
+        key_binding_enabled, gpu_attestation_mode
+    );
+
+    // --- GPU evidence collection (Phase 2: composable attestation) ---
+    #[cfg(feature = "gpu-attestation")]
+    let (gpu_entries, gpu_hashes_combined) = {
+        let mut gpu_entries = Vec::new();
+        let mut gpu_hashes_combined: Vec<u8> = Vec::new();
+        if gpu_attestation_mode != GpuAttestationMode::Disabled {
+            let providers = detect_gpu_providers();
+            if !providers.is_empty() {
+                debug!("Found {} GPU TEE provider(s)", providers.len());
+                for provider in &providers {
+                    match provider.get_evidence(&nonce) {
+                        Ok(entry) => {
+                            gpu_entries.push(entry);
+                        }
+                        Err(err) => {
+                            eprintln!("GPU {} evidence error: {}", provider.device_id(), err);
+                            std::process::exit(1);
+                        }
+                    }
+                }
+                // Ensure entries are in deterministic device_index order
+                gpu_entries.sort_by_key(|e| e.device_index);
+
+                // Build hash chain from sorted entries
+                for entry in &gpu_entries {
+                    let raw_evidence = general_purpose::STANDARD
+                        .decode(&entry.tee_evidence)
+                        .unwrap_or_else(|e| {
+                            eprintln!(
+                                "Failed to decode GPU {} evidence: {}",
+                                entry.device_index, e
+                            );
+                            std::process::exit(1);
+                        });
+                    let gpu_hash = hash_gpu_evidence(&raw_evidence);
+                    debug!(
+                        "GPU {} ({}): evidence hash = {}",
+                        entry.device_index,
+                        entry.tee_type,
+                        hex::encode(&gpu_hash)
+                    );
+                    gpu_hashes_combined.extend_from_slice(&gpu_hash);
+                }
+            }
+        }
+        (gpu_entries, gpu_hashes_combined)
+    };
+    #[cfg(not(feature = "gpu-attestation"))]
+    let gpu_hashes_combined: Vec<u8> = Vec::new();
+    let _ = &gpu_hashes_combined;
+
+    // --- Compute CPU report_data binding ---
+    let report_data: Option<Vec<u8>> = if key_binding_enabled {
+        let pubkey_der = match rsa_wrapping_key.public_key_to_der() {
+            Ok(der) => der,
+            Err(e) => {
+                eprintln!("Failed to get public key DER: {}", e);
+                std::process::exit(1);
+            }
+        };
+
+        let nonce_trimmed = nonce.trim_matches('"');
+        #[cfg(feature = "gpu-attestation")]
+        let binding = if gpu_hashes_combined.is_empty() {
+            compute_report_data_binding(nonce_trimmed.as_bytes(), &pubkey_der)
+        } else {
+            compute_report_data_binding_with_gpu(
+                nonce_trimmed.as_bytes(),
+                &pubkey_der,
+                &gpu_hashes_combined,
+            )
+        };
+        #[cfg(not(feature = "gpu-attestation"))]
+        let binding = compute_report_data_binding(nonce_trimmed.as_bytes(), &pubkey_der);
+        debug!("Report data binding (hex): {}", hex::encode(&binding));
+        Some(binding)
+    } else {
+        None
+    };
+
+    // Generate the TEE evidence with  key binding
+    let (tee_evidence, tee_type) = match tee_get_evidence(&nonce, report_data.as_deref()) {
         Ok((evidence, tee_type)) => {
             debug!("Generated TEE Evidence (Base64-encoded): {}", evidence);
             debug!("TEE Type: {}", tee_type);
@@ -238,6 +389,12 @@ async fn main() {
     };
 
     // Call the function to get the secret key using the nonce, tee_evidence, tee_type, and key_id
+    #[cfg(feature = "gpu-attestation")]
+    let gpu_evidence_ref = if gpu_entries.is_empty() {
+        None
+    } else {
+        Some(serde_json::json!(gpu_entries))
+    };
     let secret_string = match tas_get_secret_key(
         &server_uri,
         &api_key,
@@ -248,6 +405,11 @@ async fn main() {
         &wrapping_key,
         cert_path.clone(),
         &retry_config,
+        key_binding_enabled,
+        #[cfg(feature = "gpu-attestation")]
+        gpu_evidence_ref.as_ref(),
+        #[cfg(not(feature = "gpu-attestation"))]
+        None,
     )
     .await
     {

--- a/src/tas_api.rs
+++ b/src/tas_api.rs
@@ -12,6 +12,7 @@ use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
 use retry_policies::Jitter;
 use serde_json::Value;
+
 use std::fs;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -156,18 +157,30 @@ pub async fn tas_get_secret_key(
     wrapping_key: &str,
     cert_path: PathBuf,
     retry_config: &RetryConfig,
+    report_data_binding: bool,
+    gpu_evidence: Option<&serde_json::Value>,
 ) -> Result<String, String> {
     let secret_url = format!("{}/kb/v0/get_secret", server_uri);
     let client = create_client_with_root_cert(cert_path, retry_config)?;
 
     // Create the JSON body for the POST request
-    let body = serde_json::json!({
+    let mut body = serde_json::json!({
         "tee-type": tee_type,
         "nonce": nonce,
         "tee-evidence": tee_evidence,
         "key-id": key_id,
         "wrapping-key": wrapping_key
     });
+
+    // Signal key binding to the server
+    if report_data_binding {
+        body["report-data-binding"] = serde_json::json!(true);
+    }
+
+    // Include GPU evidence when available
+    if let Some(gpu_entries) = gpu_evidence {
+        body["gpu-evidence"] = gpu_entries.clone();
+    }
 
     match client
         .post(&secret_url)
@@ -346,6 +359,8 @@ MRYTnHVgon3F8Lk6ZsKGQ27CXYFMt9iIUAmkg6LmbJDqNR8NLqigo+Nfhq4rPUfP
             wrapping_key,
             cert_path,
             &no_retry_config(),
+            false,
+            None,
         )
         .await;
 
@@ -507,6 +522,8 @@ MRYTnHVgon3F8Lk6ZsKGQ27CXYFMt9iIUAmkg6LmbJDqNR8NLqigo+Nfhq4rPUfP
             wrapping_key,
             cert_path,
             &no_retry_config(),
+            false,
+            None,
         )
         .await;
 
@@ -549,6 +566,8 @@ MRYTnHVgon3F8Lk6ZsKGQ27CXYFMt9iIUAmkg6LmbJDqNR8NLqigo+Nfhq4rPUfP
             wrapping_key,
             cert_path,
             &no_retry_config(),
+            false,
+            None,
         )
         .await;
 
@@ -680,6 +699,119 @@ MRYTnHVgon3F8Lk6ZsKGQ27CXYFMt9iIUAmkg6LmbJDqNR8NLqigo+Nfhq4rPUfP
         let result = tas_get_version(&server_uri, api_key, cert_path, &test_retry_config(2)).await;
 
         assert_eq!(result.unwrap(), "\"2.0.0\"");
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_tas_get_secret_key_with_report_data_binding() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("POST", "/kb/v0/get_secret")
+            .match_body(mockito::Matcher::PartialJsonString(
+                r#"{"report-data-binding":true}"#.to_string(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"secret_key": "bound_secret"}"#)
+            .create_async()
+            .await;
+
+        let server_uri = server.url();
+        let cert_file = create_test_cert();
+        let cert_path = cert_file.path().to_path_buf();
+        let result = tas_get_secret_key(
+            &server_uri,
+            "api_key",
+            "nonce",
+            "evidence",
+            "amd-sev-snp",
+            "key1",
+            "wrapping",
+            cert_path,
+            &no_retry_config(),
+            true,
+            None,
+        )
+        .await;
+
+        assert_eq!(result.unwrap(), r#""bound_secret""#);
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_tas_get_secret_key_with_gpu_evidence() {
+        let gpu_evidence = serde_json::json!([
+            {
+                "tee-type": "nvidia-gpu",
+                "device-index": 0,
+                "tee-evidence": "gpu_report_base64"
+            }
+        ]);
+
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("POST", "/kb/v0/get_secret")
+            .match_body(mockito::Matcher::PartialJsonString(
+                r#"{"gpu-evidence":[{"tee-type":"nvidia-gpu","device-index":0,"tee-evidence":"gpu_report_base64"}]}"#.to_string(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"secret_key": "gpu_secret"}"#)
+            .create_async()
+            .await;
+
+        let server_uri = server.url();
+        let cert_file = create_test_cert();
+        let cert_path = cert_file.path().to_path_buf();
+        let result = tas_get_secret_key(
+            &server_uri,
+            "api_key",
+            "nonce",
+            "evidence",
+            "amd-sev-snp",
+            "key1",
+            "wrapping",
+            cert_path,
+            &no_retry_config(),
+            true,
+            Some(&gpu_evidence),
+        )
+        .await;
+
+        assert_eq!(result.unwrap(), r#""gpu_secret""#);
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_tas_get_secret_key_no_binding_no_gpu() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("POST", "/kb/v0/get_secret")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"secret_key": "plain_secret"}"#)
+            .create_async()
+            .await;
+
+        let server_uri = server.url();
+        let cert_file = create_test_cert();
+        let cert_path = cert_file.path().to_path_buf();
+        let result = tas_get_secret_key(
+            &server_uri,
+            "api_key",
+            "nonce",
+            "evidence",
+            "amd-sev-snp",
+            "key1",
+            "wrapping",
+            cert_path,
+            &no_retry_config(),
+            false,
+            None,
+        )
+        .await;
+
+        assert_eq!(result.unwrap(), r#""plain_secret""#);
         mock.assert_async().await;
     }
 }

--- a/src/tee_evidence.rs
+++ b/src/tee_evidence.rs
@@ -1,6 +1,6 @@
 // TEE Attestation Service Agent
 //
-// Copyright 2025 Hewlett Packard Enterprise Development LP.
+// Copyright 2025 - 2026 Hewlett Packard Enterprise Development LP.
 // SPDX-License-Identifier: MIT
 //
 // This application interacts via a REST API with the TEE Attestation Service Key Broker Module.
@@ -51,14 +51,30 @@ fn get_vmpl() -> Result<String, Box<dyn Error>> {
 
 /// Function to generate TEE evidence and return the TEE type
 ///
-/// This function takes the nonce as a parameter and returns a tuple:
 /// Requires config_tsm to be enabled in the kernel.
+///
 /// # Arguments
 /// * `nonce` - A string slice that holds the nonce value (must be exactly 64 bytes long)
+/// * `report_data` - Optional raw bytes (must be exactly 64 bytes) to write to inblob
+///   instead of the nonce string. When `Some`, enables the caller to bind the RSA public
+///   key (and optional GPU evidence hashes) into the TEE report via
+///   `SHA-512(nonce || pubkey_der [|| gpu_hashes])`. When `None`, the original
+///   nonce-as-string behaviour is used.
+///
+///   When GPU attestation is enabled, `gpu_hashes` is constructed as follows:
+///   1. Each GPU's raw attestation evidence is hashed individually with SHA-512.
+///   2. The per-GPU hashes are concatenated in device-index order:
+///      `SHA-512(gpu0) || SHA-512(gpu1) || ...`
+///   3. The concatenated result is appended to the binding input, producing:
+///      `SHA-512(nonce || pubkey_der || gpu_hashes)`
+///
 /// # Returns
 /// * `Result<(String, String), String>` - On success, returns a tuple containing the
 ///   Base64-encoded TEE evidence and the TEE type. On failure, returns an error message.
-pub fn tee_get_evidence(nonce: &str) -> Result<(String, String), String> {
+pub fn tee_get_evidence(
+    nonce: &str,
+    report_data: Option<&[u8]>,
+) -> Result<(String, String), String> {
     // Setup temp_dir_path to the config tsm report path
     let temp_dir_path = "/sys/kernel/config/tsm/report";
 
@@ -72,22 +88,34 @@ pub fn tee_get_evidence(nonce: &str) -> Result<(String, String), String> {
             nonce_bytes.len()
         ));
     }
-    let nonce = String::from_utf8(nonce_bytes.to_vec())
-        .map_err(|err| format!("Error converting nonce to string: {}", err))?;
+
+    // Determine what to write to inblob: custom report_data or the nonce string
+    let inblob_bytes: Vec<u8> = match report_data {
+        Some(rd) => {
+            if rd.len() != 64 {
+                return Err(format!(
+                    "Error: report_data must be exactly 64 bytes, but it is {} bytes",
+                    rd.len()
+                ));
+            }
+            rd.to_vec()
+        }
+        None => nonce.as_bytes().to_vec(),
+    };
 
     // Attempt to create a temporary directory inside the specified path
     let tmp_dir = tempdir_in(temp_dir_path)
         .map_err(|err| format!("Failed to create temp directory: {}", err))?;
     debug!("Temp dir created at: {:?}", tmp_dir.path());
-    debug!("Nonce_bytes (hex): {}", hex::encode(nonce_bytes));
+    debug!("Inblob bytes (hex): {}", hex::encode(&inblob_bytes));
 
     // Determine TEE type
     let tee_type =
         get_tee_type(&tmp_dir).map_err(|err| format!("Failed to determine TEE type: {}", err))?;
 
-    // Write nonce to inblob file
+    // Write inblob (report_data or nonce) to inblob file
     let inblob_file_path = tmp_dir.path().join("inblob");
-    fs::write(&inblob_file_path, nonce)
+    fs::write(&inblob_file_path, &inblob_bytes)
         .map_err(|err| format!("Failed to write to inblob file: {}", err))?;
     debug!("Wrote to inblob file at: {:?}", inblob_file_path);
 
@@ -118,4 +146,118 @@ pub fn tee_get_evidence(nonce: &str) -> Result<(String, String), String> {
     let encoded_report = general_purpose::STANDARD.encode(&tee_report);
 
     Ok((encoded_report, tee_type))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    // --- get_tee_type tests ---
+
+    #[test]
+    fn test_get_tee_type_sev_guest() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("provider"), "sev_guest\n").unwrap();
+        // get_tee_type expects a &TempDir from tempfile::TempDir, so we
+        // create one via tempdir_in.  But since get_tee_type only reads
+        // provider, we can use the same TempDir (path matches).
+        let result = get_tee_type(&dir);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "amd-sev-snp");
+    }
+
+    #[test]
+    fn test_get_tee_type_tdx_guest() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("provider"), "tdx_guest\n").unwrap();
+        let result = get_tee_type(&dir);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "intel-tdx");
+    }
+
+    #[test]
+    fn test_get_tee_type_unknown_provider() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("provider"), "some_unknown\n").unwrap();
+        let result = get_tee_type(&dir);
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("Unknown TEE provider"));
+    }
+
+    #[test]
+    fn test_get_tee_type_missing_provider_file() {
+        let dir = tempdir().unwrap();
+        // No provider file written
+        let result = get_tee_type(&dir);
+        assert!(result.is_err());
+    }
+
+    // --- Nonce validation tests ---
+
+    #[test]
+    fn test_nonce_too_short() {
+        let short_nonce = "abc"; // 3 bytes, not 64
+        let result = tee_get_evidence(short_nonce, None);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("Nonce must be exactly 64 bytes"));
+    }
+
+    #[test]
+    fn test_nonce_too_long() {
+        let long_nonce = "a".repeat(65);
+        let result = tee_get_evidence(&long_nonce, None);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("Nonce must be exactly 64 bytes"));
+    }
+
+    #[test]
+    fn test_nonce_with_surrounding_quotes_trimmed() {
+        // 66 chars with quotes, 64 after trimming
+        let quoted_nonce = format!("\"{}\"", "A".repeat(64));
+        // This will fail at the TSM directory step, but nonce validation should pass.
+        // The error should NOT be about nonce length.
+        let result = tee_get_evidence(&quoted_nonce, None);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(!err.contains("Nonce must be exactly 64 bytes"));
+    }
+
+    // --- report_data validation tests ---
+
+    #[test]
+    fn test_report_data_wrong_length() {
+        let nonce = "B".repeat(64);
+        let bad_rd = vec![0u8; 32]; // 32 bytes, not 64
+        let result = tee_get_evidence(&nonce, Some(&bad_rd));
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("report_data must be exactly 64 bytes"));
+    }
+
+    #[test]
+    fn test_report_data_too_long() {
+        let nonce = "C".repeat(64);
+        let long_rd = vec![0u8; 128];
+        let result = tee_get_evidence(&nonce, Some(&long_rd));
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("report_data must be exactly 64 bytes"));
+    }
+
+    #[test]
+    fn test_report_data_correct_length_passes_validation() {
+        let nonce = "D".repeat(64);
+        let good_rd = vec![0xABu8; 64];
+        // Will fail at TSM directory step, but report_data validation should pass.
+        let result = tee_get_evidence(&nonce, Some(&good_rd));
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(!err.contains("report_data must be exactly 64 bytes"));
+        assert!(!err.contains("Nonce must be exactly 64 bytes"));
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -31,3 +31,63 @@ where
         .map_err(|e| serde::de::Error::custom(format!("Base64 decoding error: {}", e)))?;
     Ok(T::from(decoded_bytes))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_secrets_payload_deserialize_valid() {
+        let json = serde_json::json!({
+            "wrapped_key": base64::engine::general_purpose::STANDARD.encode(b"wrapped_key_bytes"),
+            "blob": base64::engine::general_purpose::STANDARD.encode(b"encrypted_blob_data"),
+            "iv": base64::engine::general_purpose::STANDARD.encode(b"twelve_byte!"),
+            "tag": base64::engine::general_purpose::STANDARD.encode(b"sixteen_byte_tag")
+        });
+        let payload: SecretsPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.wrapped_key, b"wrapped_key_bytes");
+        assert_eq!(payload.blob, b"encrypted_blob_data");
+        assert_eq!(payload.iv, b"twelve_byte!");
+        assert_eq!(payload.tag, b"sixteen_byte_tag");
+    }
+
+    #[test]
+    fn test_secrets_payload_invalid_base64() {
+        let json = serde_json::json!({
+            "wrapped_key": "not-valid-base64!!!",
+            "blob": base64::engine::general_purpose::STANDARD.encode(b"data"),
+            "iv": base64::engine::general_purpose::STANDARD.encode(b"iv"),
+            "tag": base64::engine::general_purpose::STANDARD.encode(b"tag")
+        });
+        let result: Result<SecretsPayload, _> = serde_json::from_value(json);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Base64 decoding error"));
+    }
+
+    #[test]
+    fn test_secrets_payload_missing_field() {
+        let json = serde_json::json!({
+            "wrapped_key": base64::engine::general_purpose::STANDARD.encode(b"key"),
+            "blob": base64::engine::general_purpose::STANDARD.encode(b"blob")
+            // missing iv and tag
+        });
+        let result: Result<SecretsPayload, _> = serde_json::from_value(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_secrets_payload_empty_base64() {
+        let json = serde_json::json!({
+            "wrapped_key": base64::engine::general_purpose::STANDARD.encode(b""),
+            "blob": base64::engine::general_purpose::STANDARD.encode(b""),
+            "iv": base64::engine::general_purpose::STANDARD.encode(b""),
+            "tag": base64::engine::general_purpose::STANDARD.encode(b"")
+        });
+        let payload: SecretsPayload = serde_json::from_value(json).unwrap();
+        assert!(payload.wrapped_key.is_empty());
+        assert!(payload.blob.is_empty());
+        assert!(payload.iv.is_empty());
+        assert!(payload.tag.is_empty());
+    }
+}


### PR DESCRIPTION
Compute SHA-512(nonce || pubkey_der) and write the 64-byte hash into REPORT_DATA, cryptographically binding the agent's wrapping key to the CPU TEE attestation report (AMD SEV-SNP / Intel TDX).

Add composable GPU attestation support behind 'gpu-attestation' cargo feature: pluggable GpuEvidenceProvider trait, per-GPU SHA-512 hash chain, NvidiaGpuProvider skeleton.

Add more comprehensive tests for the changes.

Update README with build instructions for CPU-only and GPU modes.