### PR TITLE
Use policy_id to request attestation against a policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ api_key = "/etc/tas_agent/api-key"
 # Path to the CA root certificate signing the TAS REST service cert
 cert_path = "/etc/tas_agent/root_cert.pem"
 
-# ID of the key to request from the TAS REST service
-key_id = "..."
+# Policy ID to request from the TAS REST service
+policy_id = "..."
 
 # Maximum number of retry attempts for HTTP requests (default: 3)
 # max_retries = 3
@@ -93,7 +93,7 @@ If using TLS, ensure that `server_uri` specifies `https`.
 | `-c`, `--config <FILE>` | Path to the config file (default: `/etc/tas_agent/config.toml`) |
 | `--server-uri <URI>` | The URI of the TAS REST service |
 | `--api-key <FILE>` | Path to the API key for the TAS REST service |
-| `--key-id <ID>` | ID of the key to request from the TAS REST service |
+| `--policy-id <ID>` | Policy ID to request from the TAS REST service |
 | `--cert-path <FILE>` | Path to the CA root certificate signing the TAS REST service cert |
 | `--max-retries <N>` | Maximum number of retry attempts for HTTP requests (default: 3) |
 | `--retry-min-backoff-secs <SECS>` | Minimum backoff time in seconds between retries (default: 1) |
@@ -112,7 +112,7 @@ sudo ./target/debug/tas_agent -c config/config.toml
 Example output:
 
 ```
-Key-ID: 771e76e7924348899ef751d0754c9060dd805928d03043f29a065275f4f883c8
+Policy-ID: 771e76e7924348899ef751d0754c9060dd805928d03043f29a065275f4f883c8
 Value: "30786465616462656566"
 ```
 ## HTTP Retry Strategy

--- a/config/config.toml.sample
+++ b/config/config.toml.sample
@@ -8,8 +8,8 @@ api_key = "/etc/tas_agent/api-key"
 # Path to the CA root certificate signing the TAS REST service cert
 cert_path = "/etc/tas_agent/root_cert.pem"
 
-# ID of the key to request from the TAS REST service
-key_id = "..."
+# Policy ID to request from the TAS REST service
+policy_id = "..."
 
 # Maximum number of retry attempts for HTTP requests (default: 3)
 # max_retries = 3

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,9 +119,9 @@ struct Cli {
     #[arg(long, value_name = "FILE")]
     api_key: Option<PathBuf>,
 
-    /// ID of the key to request from the TAS REST service
+    /// Policy ID to request from the TAS REST service
     #[arg(long, value_name = "ID")]
-    key_id: Option<String>,
+    policy_id: Option<String>,
 
     /// Path to the CA root certificate signing the TAS REST service cert
     #[arg(long, value_name = "FILE")]
@@ -149,7 +149,8 @@ struct Cli {
 struct Config {
     server_uri: Option<String>,
     api_key: Option<PathBuf>,
-    key_id: Option<String>,
+    #[serde(alias = "key_id")]
+    policy_id: Option<String>,
     cert_path: Option<PathBuf>,
     max_retries: Option<u32>,
     retry_min_backoff_secs: Option<u64>,
@@ -195,7 +196,7 @@ async fn main() {
         }
     };
 
-    // Retrieve the REST server URI, API key, key ID, and root certificate path from
+    // Retrieve the REST server URI, API key, policy ID, and root certificate path from
     // command line, falling back to environment variables if not given
     let server_uri = cli.server_uri.unwrap_or_else(|| {
         cfg.server_uri.unwrap_or_else(|| {
@@ -208,9 +209,9 @@ async fn main() {
         cfg.api_key
             .unwrap_or_else(|| PathBuf::from("/etc/tas_agent/api_key".to_string()))
     });
-    let key_id = cli.key_id.unwrap_or_else(|| {
-        cfg.key_id.unwrap_or_else(|| {
-            eprintln!("server key ID is required");
+    let policy_id = cli.policy_id.unwrap_or_else(|| {
+        cfg.policy_id.unwrap_or_else(|| {
+            eprintln!("server policy ID is required");
             std::process::exit(1)
         })
     });
@@ -391,7 +392,8 @@ async fn main() {
         }
     };
 
-    // Call the function to get the secret key using the nonce, tee_evidence, tee_type, and key_id
+    // Call the function to get the secret key using the nonce, tee_evidence,
+    // tee_type, and policy_id
     #[cfg(feature = "gpu-attestation")]
     let gpu_evidence_ref = if gpu_entries.is_empty() {
         None
@@ -404,7 +406,7 @@ async fn main() {
         &nonce,
         &tee_evidence,
         &tee_type,
-        &key_id,
+        &policy_id,
         &wrapping_key,
         cert_path.clone(),
         &retry_config,

--- a/src/tas_api.rs
+++ b/src/tas_api.rs
@@ -153,7 +153,7 @@ pub async fn tas_get_secret_key(
     nonce: &str,
     tee_evidence: &str,
     tee_type: &str,
-    key_id: &str,
+    policy_id: &str,
     wrapping_key: &str,
     cert_path: PathBuf,
     retry_config: &RetryConfig,
@@ -168,7 +168,7 @@ pub async fn tas_get_secret_key(
         "tee-type": tee_type,
         "nonce": nonce,
         "tee-evidence": tee_evidence,
-        "key-id": key_id,
+        "policy-id": policy_id,
         "wrapping-key": wrapping_key
     });
 
@@ -345,7 +345,7 @@ MRYTnHVgon3F8Lk6ZsKGQ27CXYFMt9iIUAmkg6LmbJDqNR8NLqigo+Nfhq4rPUfP
         let nonce = "abc123";
         let tee_evidence = "base64_encoded_report";
         let tee_type = "amd-sev-snp";
-        let key_id = "key123";
+        let policy_id = "policy123";
         let wrapping_key = "wrapping_key";
         let cert_file = create_test_cert();
         let cert_path = cert_file.path().to_path_buf();
@@ -355,7 +355,7 @@ MRYTnHVgon3F8Lk6ZsKGQ27CXYFMt9iIUAmkg6LmbJDqNR8NLqigo+Nfhq4rPUfP
             nonce,
             tee_evidence,
             tee_type,
-            key_id,
+            policy_id,
             wrapping_key,
             cert_path,
             &no_retry_config(),
@@ -508,7 +508,7 @@ MRYTnHVgon3F8Lk6ZsKGQ27CXYFMt9iIUAmkg6LmbJDqNR8NLqigo+Nfhq4rPUfP
         let nonce = "abc123";
         let tee_evidence = "base64_encoded_report";
         let tee_type = "amd-sev-snp";
-        let key_id = "key123";
+        let policy_id = "policy123";
         let wrapping_key = "wrapping_key";
         let cert_file = create_test_cert();
         let cert_path = cert_file.path().to_path_buf();
@@ -518,7 +518,7 @@ MRYTnHVgon3F8Lk6ZsKGQ27CXYFMt9iIUAmkg6LmbJDqNR8NLqigo+Nfhq4rPUfP
             nonce,
             tee_evidence,
             tee_type,
-            key_id,
+            policy_id,
             wrapping_key,
             cert_path,
             &no_retry_config(),
@@ -552,7 +552,7 @@ MRYTnHVgon3F8Lk6ZsKGQ27CXYFMt9iIUAmkg6LmbJDqNR8NLqigo+Nfhq4rPUfP
         let nonce = "abc123";
         let tee_evidence = "base64_encoded_report";
         let tee_type = "amd-sev-snp";
-        let key_id = "key123";
+        let policy_id = "policy123";
         let wrapping_key = "wrapping_key";
         let cert_file = create_test_cert();
         let cert_path = cert_file.path().to_path_buf();
@@ -562,7 +562,7 @@ MRYTnHVgon3F8Lk6ZsKGQ27CXYFMt9iIUAmkg6LmbJDqNR8NLqigo+Nfhq4rPUfP
             nonce,
             tee_evidence,
             tee_type,
-            key_id,
+            policy_id,
             wrapping_key,
             cert_path,
             &no_retry_config(),
@@ -725,7 +725,7 @@ MRYTnHVgon3F8Lk6ZsKGQ27CXYFMt9iIUAmkg6LmbJDqNR8NLqigo+Nfhq4rPUfP
             "nonce",
             "evidence",
             "amd-sev-snp",
-            "key1",
+            "policy1",
             "wrapping",
             cert_path,
             &no_retry_config(),
@@ -769,7 +769,7 @@ MRYTnHVgon3F8Lk6ZsKGQ27CXYFMt9iIUAmkg6LmbJDqNR8NLqigo+Nfhq4rPUfP
             "nonce",
             "evidence",
             "amd-sev-snp",
-            "key1",
+            "policy1",
             "wrapping",
             cert_path,
             &no_retry_config(),
@@ -802,7 +802,7 @@ MRYTnHVgon3F8Lk6ZsKGQ27CXYFMt9iIUAmkg6LmbJDqNR8NLqigo+Nfhq4rPUfP
             "nonce",
             "evidence",
             "amd-sev-snp",
-            "key1",
+            "policy1",
             "wrapping",
             cert_path,
             &no_retry_config(),
@@ -829,7 +829,7 @@ MRYTnHVgon3F8Lk6ZsKGQ27CXYFMt9iIUAmkg6LmbJDqNR8NLqigo+Nfhq4rPUfP
             .match_body(mockito::Matcher::AllOf(vec![
                 mockito::Matcher::PartialJsonString(r#"{"tee-type":"amd-sev-snp"}"#.to_string()),
                 mockito::Matcher::PartialJsonString(r#"{"nonce":"abc123"}"#.to_string()),
-                mockito::Matcher::PartialJsonString(r#"{"key-id":"key1"}"#.to_string()),
+                mockito::Matcher::PartialJsonString(r#"{"policy-id":"policy1"}"#.to_string()),
             ]))
             .with_status(200)
             .with_header("content-type", "application/json")
@@ -844,7 +844,7 @@ MRYTnHVgon3F8Lk6ZsKGQ27CXYFMt9iIUAmkg6LmbJDqNR8NLqigo+Nfhq4rPUfP
             "abc123",
             "evidence",
             "amd-sev-snp",
-            "key1",
+            "policy1",
             "wrapping",
             cert_file.path().to_path_buf(),
             &no_retry_config(),
@@ -898,7 +898,7 @@ MRYTnHVgon3F8Lk6ZsKGQ27CXYFMt9iIUAmkg6LmbJDqNR8NLqigo+Nfhq4rPUfP
         let mock = server
             .mock("POST", "/kb/v0/get_secret")
             .match_body(mockito::Matcher::JsonString(
-                r#"{"tee-type":"amd-sev-snp","nonce":"nonce","tee-evidence":"evidence","key-id":"key1","wrapping-key":"wrapping"}"#
+                r#"{"tee-type":"amd-sev-snp","nonce":"nonce","tee-evidence":"evidence","policy-id":"policy1","wrapping-key":"wrapping"}"#
                     .to_string(),
             ))
             .with_status(200)
@@ -914,7 +914,7 @@ MRYTnHVgon3F8Lk6ZsKGQ27CXYFMt9iIUAmkg6LmbJDqNR8NLqigo+Nfhq4rPUfP
             "nonce",
             "evidence",
             "amd-sev-snp",
-            "key1",
+            "policy1",
             "wrapping",
             cert_file.path().to_path_buf(),
             &no_retry_config(),
@@ -953,7 +953,7 @@ MRYTnHVgon3F8Lk6ZsKGQ27CXYFMt9iIUAmkg6LmbJDqNR8NLqigo+Nfhq4rPUfP
             "nonce",
             "evidence",
             "amd-sev-snp",
-            "key1",
+            "policy1",
             "wrapping",
             cert_file.path().to_path_buf(),
             &no_retry_config(),


### PR DESCRIPTION
# Switch agent secret request from key_id to policy_id

## Summary

This PR updates the TAS agent to identify policies by `policy_id` when requesting secrets from the TAS server, and aligns CLI options, configuration, and documentation accordingly.

## Changes

- **Request payload**: The `get_secret` POST body now sends `"policy-id"` instead of `"key-id"`.
- **Function signature**: `tas_get_secret_key` parameter renamed from `key_id` to `policy_id`.
- **CLI**: `--key-id` argument renamed to `--policy-id`.
- **Config**: `key_id` config key renamed to `policy_id`; a `#[serde(alias = "key_id")]` ensures existing config files continue to work without changes.
- **README**: Updated CLI option table, config example, and sample output to use `policy_id` terminology.
- **Sample config**: `config/config.toml.sample` updated to `policy_id`.
- **Tests**: All mock body matchers and test variables updated to assert `"policy-id"` in the JSON payload.