### PR TITLE
feat(certify): implement TAS certificate issuance flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,8 +409,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "der_derive",
+ "flagset",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -477,6 +490,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "fnv"
@@ -730,6 +749,17 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
+]
 
 [[package]]
 name = "http"
@@ -1963,6 +1993,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2133,6 +2174,7 @@ dependencies = [
  "cipher",
  "clap",
  "hex",
+ "hostname",
  "log",
  "mockito",
  "nv-attestation-sdk",
@@ -2150,6 +2192,8 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
+ "uuid",
+ "x509-cert",
  "zeroize",
 ]
 
@@ -2203,6 +2247,27 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2411,6 +2476,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "vcpkg"
@@ -2929,6 +3005,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid",
+ "der",
+ "sha1",
+ "signature",
+ "spki",
+ "tls_codec",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2997,6 +3087,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,10 @@ tempfile = "3.6"
 base64 = "0.21"
 hex = "0.4"
 rsa = { version = "0.9.8", features = ["sha2"] }
-sha2 = "0.10"
+sha2 = { version = "0.10", features = ["oid"] }
+x509-cert = { version = "0.2", features = ["builder", "pem"], optional = true }
+uuid = { version = "1", features = ["v4"], optional = true }
+hostname = { version = "0.4", optional = true }
 # Only needed for askpass, which must read CLOCK_MONOTONIC directly.
 rustix = { version = "1.0.7", features = ["time"], optional = true }
 # 0.8 required by rsa
@@ -38,6 +41,7 @@ nv-attestation-sdk = { git = "https://github.com/NVIDIA/attestation-sdk", tag = 
 gpu-nvidia = ["dep:nv-attestation-sdk"]
 askpass = ["dep:rustix"]
 passfifo = []
+certify = ["dep:x509-cert", "dep:uuid", "dep:hostname"]
 
 [dev-dependencies]
 mockito = "1.7"

--- a/config/config.toml.sample
+++ b/config/config.toml.sample
@@ -26,6 +26,10 @@ policy_id = "..."
 # Maximum backoff time in seconds between retries (default: 30)
 # retry_max_backoff_secs = 30
 
+# Enable certificate CSR generation mode
+# (requires the 'certify' feature to be enabled at build time)
+# certify = false
+
 # Enable systemd ask-password watcher mode for automatic LUKS unlock
 # (requires the 'askpass' feature to be enabled at build time)
 # askpass = false

--- a/docs/experimental/certify.md
+++ b/docs/experimental/certify.md
@@ -1,0 +1,227 @@
+# Certificate Issuance & Renewal (`certify`) — EXPERIMENTAL
+
+> **⚠️ EXPERIMENTAL — NOT FOR PRODUCTION USE**
+>
+> The `certify` feature and its certificate issuance/renewal lifecycle are
+> experimental and under active development. The command-line flags, on-disk
+> file layout, configuration keys, and TAS API payloads described here are
+> **subject to change without notice**. This feature has not been hardened or
+> audited for production deployments. Do not rely on it for production
+> workloads or to protect production secrets.
+
+## Overview
+
+The `certify` feature enables the TAS Agent to obtain an X.509 certificate from
+the TEE Attestation Service (TAS) by submitting a CSR together with bound TEE
+evidence, and to later renew that certificate while reusing the original private
+key.
+
+Two lifecycle operations are supported:
+
+- **Initial certification** (`--certify`): generates a fresh RSA-4096 key,
+  builds a CSR, gathers TEE evidence, and requests a new certificate.
+- **Renewal** (`--renew`): reuses the previously generated private key and the
+  previously issued certificate to request a refreshed certificate.
+
+The agent sets the CSR subject Common Name (CN) from the host's identity: it
+uses the host's fully-qualified domain name (FQDN) when one is available, and
+otherwise falls back to the short hostname. A short random suffix is appended to
+the CN.
+
+The certificate identity (SPIFFE ID / UUID) is minted server-side by TAS. The
+agent's CSR only contributes the public key and this CN; the agent never asserts
+its own identity.
+
+## Building
+
+The feature is gated behind the `certify` Cargo feature and is **off by
+default**. Build the agent with the feature enabled:
+
+```bash
+# Debug build
+cargo build --features certify
+
+# Release build
+cargo build --release --features certify
+```
+
+The resulting binary is at `target/debug/tas_agent` (or
+`target/release/tas_agent`).
+
+> Note: RSA-4096 key generation is slow in debug builds. Use a release build
+> for faster key generation.
+
+## Source layout
+
+All certify/renew code lives under the feature-gated `src/certify/` module and
+is compiled only with `--features certify`. The rest of the codebase contains no
+certify-specific logic, so the feature can be developed in isolation:
+
+- `src/certify/mod.rs` — flow orchestration (`certify_flow`), CLI/config
+  dispatch (`run_if_requested`), the experimental runtime warning, and the
+  `CertifyArgs` / `CertifyConfig` structs that define the certify CLI flags and
+  config keys.
+- `src/certify/api.rs` — certify/renew TAS REST calls (`tas_certify`,
+  `tas_get_alpha_nonce`) and their request/response payload types.
+- `src/certify/keygen.rs` — RSA-4096 key generation.
+- `src/certify/csr.rs` — CSR construction and Common Name derivation.
+- `src/certify/material_writer.rs` — atomic on-disk material writes.
+- `src/certify/renewal_input.rs` — loading existing key/cert for renewal.
+
+The certify CLI flags and config keys are defined as `CertifyArgs` /
+`CertifyConfig` inside the module and flattened (`#[command(flatten)]` /
+`#[serde(flatten)]`) into the top-level `Cli` / `Config` in `src/main.rs`. The
+flag names (`--certify`, `--renew`, `--write-dir`, `--force`) and TOML keys stay
+identical; only their definitions moved into the module.
+
+The core `src/tas_api.rs` holds only the non-experimental endpoints. The certify
+API in `src/certify/api.rs` reuses its `pub(crate)` `create_client` helper, so
+core API code is never touched by certify development.
+
+## Runtime warning
+
+Because the lifecycle is experimental, every certify/renew run logs the
+following warning before contacting the TAS server:
+
+```text
+EXPERIMENTAL: certify/renew lifecycle is not production-ready
+```
+
+## Command-line flags
+
+The following flags are only available when compiled with `--features certify`:
+
+| Flag | Argument | Description |
+| --- | --- | --- |
+| `--certify` | _(none)_ | Initial certification mode. Generates a new key and requests a certificate. |
+| `--renew` | _(none)_ | Renewal mode. Reuses the existing key and certificate from `--write-dir`. |
+| `--write-dir <DIR>` | directory | **Required** for `--certify` and `--renew`. Directory where key/certificate materials are written and read. |
+| `--force` | _(none)_ | Allow overwriting an existing `key.pem` during initial certification. |
+
+These shared flags also apply:
+
+| Flag | Argument | Description |
+| --- | --- | --- |
+| `-d`, `--debug` | _(none)_ | Enable debug logging. Also writes the issued certificate bundle to stdout. |
+| `-c`, `--config <FILE>` | file | Path to the config file (default: `/etc/tas_agent/config.toml`). |
+| `--server-uri <URI>` | URI | TAS REST service URI. Must start with `http://` or `https://`. **Required.** |
+| `--api-key <FILE>` | file | Path to the API key file (default: `/etc/tas_agent/api-key`). |
+| `--policy-id <ID>` | ID | Policy domain to request. **Required** for the certify flow. |
+| `--cert-path <FILE>` | file | CA root certificate that signs the TAS service certificate (default: `/etc/tas_agent/root_cert.pem`). |
+| `--max-retries <N>` | integer | Maximum HTTP retry attempts (default: 3). |
+| `--retry-min-backoff-secs <SECS>` | integer | Minimum retry backoff in seconds (default: 1). |
+| `--retry-max-backoff-secs <SECS>` | integer | Maximum retry backoff in seconds (default: 30). |
+
+## Configuration file
+
+The lifecycle flags may also be set in the TOML config file instead of (or in
+addition to) the command line. CLI flags take precedence over config values.
+
+```toml
+# Enable certificate certification mode
+certify = true
+
+# Enable renewal mode (mutually exclusive intent with certify; renew takes priority)
+# renew = true
+
+# Directory for certificate materials (equivalent to --write-dir)
+write_dir = "/var/lib/tas_agent/certs"
+
+# Allow overwriting an existing key.pem during certification
+# force = false
+```
+
+The existing `server_uri`, `api_key`, `policy_id`, `cert_path`, and retry
+settings are shared with the normal key-fetch flow.
+
+## On-disk file layout
+
+All materials are written to the directory given by `--write-dir`. The agent
+creates the directory if it does not exist.
+
+| File | Description | Initial certify | Renewal |
+| --- | --- | --- | --- |
+| `key.pem` | PKCS#8 private key | Created (once) | Preserved (reused) |
+| `cert.pem` | Issued leaf certificate | Written | Replaced |
+| `chain.pem` | CA chain | Written | Replaced |
+| `ca-bundle.pem` | CA bundle | Written | Replaced |
+
+Certificate materials are written atomically (temp file + rename). During
+initial certification, `key.pem` is created with an exclusive (no-overwrite)
+flag and the agent refuses to overwrite an existing key unless `--force` is
+given.
+
+## Usage
+
+### Initial certification
+
+Generates a new key, requests a certificate, and writes all materials to the
+write directory.
+
+```bash
+sudo target/debug/tas_agent -d \
+  -c ~/config.toml \
+  --certify \
+  --write-dir /var/lib/tas_agent/certs
+```
+
+To overwrite an existing `key.pem` (re-certify from scratch), add `--force`:
+
+```bash
+sudo target/debug/tas_agent -d \
+  -c ~/config.toml \
+  --certify --force \
+  --write-dir /var/lib/tas_agent/certs
+```
+
+### Renewal
+
+Reuses the existing `key.pem` and `cert.pem` from the write directory, requests
+a refreshed certificate, and atomically updates `cert.pem`, `chain.pem`, and
+`ca-bundle.pem`. The private key is preserved.
+
+```bash
+sudo target/debug/tas_agent -d \
+  -c ~/config.toml \
+  --renew \
+  --write-dir /var/lib/tas_agent/certs
+```
+
+## Verification
+
+After initial certification, inspect the issued material:
+
+```bash
+ls -l /var/lib/tas_agent/certs/
+openssl x509 -in /var/lib/tas_agent/certs/cert.pem -noout -text
+```
+
+After renewal, confirm the certificate changed while the key was preserved. The
+key modulus should be identical before and after renewal; the certificate
+serial number should differ:
+
+```bash
+# Key modulus (should be identical before and after renewal)
+openssl rsa -in /var/lib/tas_agent/certs/key.pem -noout -modulus | openssl md5
+
+# Certificate serial (should change after renewal)
+openssl x509 -in /var/lib/tas_agent/certs/cert.pem -noout -serial
+```
+
+## Requirements
+
+- A reachable TAS server exposing the `alphav1` certify and nonce endpoints,
+  with support for the renewal payload field.
+- A valid API key file.
+- A policy domain (policy ID) configured on the TAS server.
+- A CA root certificate for validating the TAS service certificate (for HTTPS).
+- The host must be able to produce TEE evidence (e.g., running inside a
+  supported confidential VM).
+
+## Limitations
+
+- Experimental: flags, file layout, config keys, and API payloads may change.
+- The renewal flow requires that `key.pem` and `cert.pem` already exist in the
+  write directory from a prior successful certification.
+- RSA-4096 key generation is slow in debug builds.
+- Not hardened or audited for production use.

--- a/src/certify/api.rs
+++ b/src/certify/api.rs
@@ -1,0 +1,340 @@
+// TEE Attestation Service Agent
+//
+// Copyright 2025 - 2026 Hewlett Packard Enterprise Development LP.
+// SPDX-License-Identifier: MIT
+//
+// EXPERIMENTAL: certify/renew-specific TAS REST API calls and payload types.
+// Gated behind the off-by-default `certify` Cargo feature. The core TAS API
+// lives in `src/tas_api.rs`; this module reuses its `create_client` helper.
+
+use std::path::PathBuf;
+
+use base64::{engine::general_purpose, Engine};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use x509_cert::der::{DecodePem, Encode};
+use x509_cert::request::CertReq;
+
+use crate::tas_api::{create_client, RetryConfig};
+
+#[derive(Debug, Deserialize)]
+pub struct CertifyResponse {
+    pub certificate: String,
+    #[serde(default)]
+    pub ca_chain: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct CertifyRequest<'a> {
+    #[serde(rename = "tee-type")]
+    tee_type: &'a str,
+    nonce: &'a str,
+    #[serde(rename = "tee-evidence")]
+    tee_evidence: &'a str,
+    csr: String,
+    #[serde(rename = "policy-domain")]
+    policy_domain: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "renew_cert")]
+    renew_cert: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "gpu-evidence")]
+    gpu_evidence: Option<&'a serde_json::Value>,
+}
+
+pub async fn tas_get_alpha_nonce(
+    server_uri: &str,
+    api_key: &str,
+    cert_path: PathBuf,
+    retry_config: &RetryConfig,
+) -> Result<String, String> {
+    let nonce_url = format!("{}/alphav1/nonce", server_uri);
+    let client = create_client(server_uri, cert_path, retry_config)?;
+
+    match client
+        .get(&nonce_url)
+        .header("X-API-KEY", api_key)
+        .send()
+        .await
+    {
+        Ok(response) => {
+            if response.status().is_success() {
+                match response.json::<Value>().await {
+                    Ok(json) => json
+                        .get("nonce")
+                        .and_then(Value::as_str)
+                        .map(|nonce| nonce.to_string())
+                        .ok_or_else(|| "Error: 'nonce' field not found in response".to_string()),
+                    Err(err) => Err(format!("Error parsing JSON response: {}", err)),
+                }
+            } else {
+                Err(format!(
+                    "Error: Received HTTP {} with message: {}",
+                    response.status(),
+                    response
+                        .text()
+                        .await
+                        .unwrap_or_else(|_| "Unable to read response body".to_string())
+                ))
+            }
+        }
+        Err(err) => Err(format!("Error making request: {}", err)),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn tas_certify(
+    server_uri: &str,
+    api_key: &str,
+    nonce: &str,
+    tee_evidence: &str,
+    tee_type: &str,
+    renew_cert: Option<&str>,
+    csr_pem: &str,
+    policy_domain: &str,
+    cert_path: PathBuf,
+    retry_config: &RetryConfig,
+    gpu_evidence: Option<&serde_json::Value>,
+) -> Result<CertifyResponse, String> {
+    let certify_url = format!("{}/alphav1/certify", server_uri);
+    let client = create_client(server_uri, cert_path, retry_config)?;
+
+    let cert_req = CertReq::from_pem(csr_pem)
+        .map_err(|err| format!("Failed to parse CSR PEM for certify request: {}", err))?;
+    let csr_der = cert_req
+        .to_der()
+        .map_err(|err| format!("Failed to encode CSR DER for certify request: {}", err))?;
+    let csr_der_b64 = general_purpose::STANDARD.encode(csr_der);
+
+    let body = CertifyRequest {
+        tee_type,
+        nonce,
+        renew_cert,
+        tee_evidence,
+        csr: csr_der_b64,
+        policy_domain,
+        gpu_evidence,
+    };
+
+    match client
+        .post(&certify_url)
+        .header("X-API-KEY", api_key)
+        .json(&body)
+        .send()
+        .await
+    {
+        Ok(response) => {
+            if response.status().as_u16() == 200 || response.status().as_u16() == 201 {
+                response
+                    .json::<CertifyResponse>()
+                    .await
+                    .map_err(|err| format!("Error parsing JSON response: {}", err))
+            } else {
+                Err(format!(
+                    "Error: Received HTTP {} with message: {}",
+                    response.status(),
+                    response
+                        .text()
+                        .await
+                        .unwrap_or_else(|_| "Unable to read response body".to_string())
+                ))
+            }
+        }
+        Err(err) => Err(format!("Error making request: {}", err)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockito::Server;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn no_retry_config() -> RetryConfig {
+        RetryConfig {
+            max_retries: 0,
+            min_backoff_secs: 0,
+            max_backoff_secs: 0,
+        }
+    }
+
+    fn create_test_cert() -> NamedTempFile {
+        let mut temp_file = NamedTempFile::new().expect("Failed to create temporary file");
+        let cert_content = r#"
+-----BEGIN CERTIFICATE-----
+MIIFATCCAumgAwIBAgIRANd0Vl3DsRLwMPsH2hKdJAwwDQYJKoZIhvcNAQELBQAw
+WjELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAlRYMQ8wDQYDVQQHEwZBdXN0aW4xDzAN
+BgNVBAoTBlRoYWxlczEcMBoGA1UEAxMTQ2lwaGVyVHJ1c3QgUm9vdCBDQTAeFw0y
+NTA1MTIwOTU4MDlaFw0zNTAzMjQxODA2MTBaMGQxCzAJBgNVBAYTAlVTMREwDwYD
+VQQIEwhDb2xvcmFkbzEVMBMGA1UEBxMMRm9ydCBDb2xsaW5zMR0wGwYDVQQKExRI
+ZXdsZXR0IFBhY2thcmQgTGFiczEMMAoGA1UEAxMDVEFTMIIBIjANBgkqhkiG9w0B
+AQEFAAOCAQ8AMIIBCgKCAQEAhaPsSZPmVO8Mpd8OjWxZqWAWjLhBCVWUwR2hVF6C
+JJgPQijUsQt3Dyx0MZWfgb1qLwrzWTGWKnq8LvhUj/xmWvDL9YmLTBlqq0s5HcwI
+9QVm+UtKLXBQzMi4zhELhydkUFvy3qysM1x6VQVNeG9qhKXfonOwFvDsJYD01FiC
+447guAUoqIVecrEZUJA/m8EpU8dMhMdjLqswFLi9bVtg6F65Nb4YyQNnCRVsr0hA
+JYeZv42CEd4HINK2n7xXmLcAsW6uoBY8qXcEbE2jqs4274vXZ74trfJrWj/GW8uL
+jzuxsc6Nh3t5coTnuBQjebSPeX7DaJbLZ9M15ASnuVfj1QIDAQABo4G3MIG0MA4G
+A1UdDwEB/wQEAwIDiDATBgNVHSUEDDAKBggrBgEFBQcDATAMBgNVHRMBAf8EAjAA
+MB8GA1UdIwQYMBaAFAtzTvWEmr72yaVeWNW0mjrVZlZmMF4GA1UdHwRXMFUwU6BR
+oE+GTWh0dHA6Ly9jaXBoZXJ0cnVzdG1hbmFnZXIubG9jYWwvY3Jscy8xOTcyNTVm
+Ny1mNmRjLTQ0YTUtYWNiOC1mNTEyZDMyYWEyNjMuY3JsMA0GCSqGSIb3DQEBCwUA
+A4ICAQDEt3PUqsMNP5PI2iB4z2QXbBa9B3ndYEbFl16L0b4quI1mONM4VeKbTUQk
+k1aXC1Q8Wbhfi5GrtESp/Gac0CGM3w8oX9yLYWO9e/XJO5MIfxprgS2IgKRNVa81
+1gDjdAnxMhzcIy5iV7p6atprITdyKTj07VuU9qmbJKPDNeUjdKfujvbUFYInRUDd
+n6FkGOeK0lzzNxxby/z1qdI3WlLFioq1HvAeHQVueH54vePI3QwnTk6qmcl8RHn0
+pWeOkiqgnincMCnsnhyrnMDsX/DNSF7mwynIJQxBfOOp7pFBpzubY4gvhRQ3lkmV
+Uc2wNeK9M9uiPTBJAwRmialJHogIfQbKgL/iWTWdw2O1JIVta+oXHiTgLJVsJz7P
+NQSfBe+CfcAYe6cQzUkUQT5hJVvLoQM+hJrITehQWKrSdokhJwkbpPweNeGAAlEy
+d7/kIkP8k/rsQz7Da9GjUjGhS+VMkAz9BBU6FiDXJZyJFmeEJe5fgsbRGX8wvuqn
+uBIrBSk/RT5n1J62+FQOhb9NbcwyYKza9rmYahSRlmXe5Ct5LwPz3AZXlSfbsFOn
+MRYTnHVgon3F8Lk6ZsKGQ27CXYFMt9iIUAmkg6LmbJDqNR8NLqigo+Nfhq4rPUfP
+43Pv68i6IWf8wqoiBgOIsHaauphoZjoOIDRWYmb9OQ9yI0+eUw==
+-----END CERTIFICATE-----
+"#;
+        temp_file
+            .write_all(cert_content.as_bytes())
+            .expect("Failed to write to temporary file");
+        temp_file
+    }
+
+    fn sample_csr_pem() -> &'static str {
+        r#"-----BEGIN CERTIFICATE REQUEST-----
+MIICYDCCAUgCAQAwGzEZMBcGA1UEAwwQdGVzdC5leGFtcGxlLmNvbTCCASIwDQYJ
+KoZIhvcNAQEBBQADggEPADCCAQoCggEBAMR4qWlFXawpabqezK5iwuxUcJL8yHe/
+RGBKi5nueLWRaV8169T5diNeXI5DXxKv/RV+hPzeJcAsPoZxiRJdMBecImLW4N4L
+tYFdoguiPacZoZEGNLu9ntANN1E+MYkAw9RHq+ynyhh4EUxEZFDNVOHxQ3Kf4DoK
+q/b0ByUnKucNI3WSB1AfBG+wqqmRza5BnDuHubZ+18Pib9xIlBlAio6PltrfRACB
+dFQ2SjDqQksWRzNJ3/+Q60po+HtnhW3CduKDNzmh5E3gPFrt5Ami5qos4w4ddcsD
+J1EmL7xeC4avsnoXqoXA10chX7Ze2tV41WCzh9ImR3925owhcF09tckCAwEAAaAA
+MA0GCSqGSIb3DQEBCwUAA4IBAQBk0pgsolCfzTdCOXkvP4qZQwfAyIIgm2qClAyC
+LH5YGbecanqHE9VQWU/JVGcsNkQcyed8vZ8Sf/IoTdKWbKFozRoglmk7+piWnkCL
+A5Fc4yyg1wx3TW6HFRR2Z7YMZpvAVln3qymOpxUvsEkg2o2f/R8VwDhJ3ubAuEFM
+SOA6EhgFE5Dwieu7o/Vt092EyH2gMcllM2We2Zg89QVKbmqJLzMBXsdgGov36zgH
+ISXfQJBHHM6UgrnAWYpTzlsCF1ZC1BHOi2ZG20BGaIRvFNMjLMeDCBY6EydUgsPy
+CzWyyc0J/7PWdmvFVgXukRznKqZp/d4xAaQIKxLcxGwwDNp1
+-----END CERTIFICATE REQUEST-----
+"#
+    }
+
+    #[tokio::test]
+    async fn test_tas_get_alpha_nonce_success() {
+        let mut server = Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/alphav1/nonce")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"nonce":"alpha-nonce-123"}"#)
+            .create_async()
+            .await;
+
+        let cert_file = create_test_cert();
+        let result = tas_get_alpha_nonce(
+            &server.url(),
+            "key",
+            cert_file.path().to_path_buf(),
+            &no_retry_config(),
+        )
+        .await;
+
+        assert_eq!(result.unwrap(), "alpha-nonce-123");
+    }
+
+    #[tokio::test]
+    async fn test_tas_get_alpha_nonce_missing_nonce_field() {
+        let mut server = Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/alphav1/nonce")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"wrong":"value"}"#)
+            .create_async()
+            .await;
+
+        let cert_file = create_test_cert();
+        let result = tas_get_alpha_nonce(
+            &server.url(),
+            "key",
+            cert_file.path().to_path_buf(),
+            &no_retry_config(),
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("'nonce' field not found"));
+    }
+
+    #[tokio::test]
+    async fn test_tas_certify_success_and_request_fields() {
+        let csr_der = CertReq::from_pem(sample_csr_pem())
+            .unwrap()
+            .to_der()
+            .unwrap();
+        let expected_csr_b64 = general_purpose::STANDARD.encode(csr_der);
+        let expected_body = format!(
+            r#"{{"tee-type":"amd-sev-snp","nonce":"nonce123","tee-evidence":"dGVzdC1ldmlkZW5jZQ==","csr":"{}","policy-domain":"tenant-a"}}"#,
+            expected_csr_b64
+        );
+
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("POST", "/alphav1/certify")
+            .match_body(mockito::Matcher::JsonString(expected_body))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"certificate":"-----BEGIN CERTIFICATE-----\nleaf\n-----END CERTIFICATE-----","ca_chain":["-----BEGIN CERTIFICATE-----\nca1\n-----END CERTIFICATE-----"]}"#,
+            )
+            .create_async()
+            .await;
+
+        let cert_file = create_test_cert();
+        let result = tas_certify(
+            &server.url(),
+            "key",
+            "nonce123",
+            "dGVzdC1ldmlkZW5jZQ==",
+            "amd-sev-snp",
+            None,
+            sample_csr_pem(),
+            "tenant-a",
+            cert_file.path().to_path_buf(),
+            &no_retry_config(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(result.certificate.contains("BEGIN CERTIFICATE"));
+        assert_eq!(result.ca_chain.len(), 1);
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_tas_certify_http_error() {
+        let mut server = Server::new_async().await;
+        let _mock = server
+            .mock("POST", "/alphav1/certify")
+            .with_status(400)
+            .with_body("bad request")
+            .create_async()
+            .await;
+
+        let cert_file = create_test_cert();
+        let result = tas_certify(
+            &server.url(),
+            "key",
+            "nonce123",
+            "dGVzdC1ldmlkZW5jZQ==",
+            "amd-sev-snp",
+            None,
+            sample_csr_pem(),
+            "tenant-a",
+            cert_file.path().to_path_buf(),
+            &no_retry_config(),
+            None,
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Received HTTP 400"));
+    }
+}

--- a/src/certify/csr.rs
+++ b/src/certify/csr.rs
@@ -1,0 +1,252 @@
+// TEE Attestation Service Agent
+//
+// Copyright 2026 Hewlett Packard Enterprise Development LP.
+// SPDX-License-Identifier: MIT
+//
+// Plain PKCS#10 CSR construction for the TAS certificate flow.
+
+use crate::certify::keygen::AgentKey;
+use rsa::pkcs1v15::Signature;
+use rsa::signature::{Keypair, Signer};
+use std::error::Error;
+use std::str::FromStr;
+use uuid::Uuid;
+use x509_cert::der::pem::LineEnding;
+use x509_cert::der::{Encode, EncodePem};
+use x509_cert::name::Name;
+use x509_cert::request::{CertReq, CertReqInfo};
+use x509_cert::spki::{
+    DynSignatureAlgorithmIdentifier, SignatureBitStringEncoding, SubjectPublicKeyInfoOwned,
+};
+
+const MAX_FQDN_COMPONENT_LEN: usize = 47;
+const MAX_HOSTNAME_COMPONENT_LEN: usize = 32;
+const UUID_SUFFIX_HEX_LEN: usize = 12;
+
+pub fn generate_tee_common_name() -> String {
+    let uuid = Uuid::new_v4();
+
+    if let Some(fqdn) = preferred_fqdn_for_cn() {
+        return generate_tee_common_name_from_fqdn(Some(&fqdn), uuid);
+    }
+
+    let hostname = hostname::get()
+        .ok()
+        .and_then(|name| name.into_string().ok())
+        .map(|name| name.trim().to_string())
+        .filter(|name| !name.is_empty());
+    generate_tee_common_name_from_hostname(hostname.as_deref(), uuid)
+}
+
+fn preferred_fqdn_for_cn() -> Option<String> {
+    #[cfg(unix)]
+    {
+        if let Some(fqdn) = try_get_fqdn_from_hostname_command() {
+            return Some(fqdn);
+        }
+    }
+
+    None
+}
+
+#[cfg(unix)]
+fn try_get_fqdn_from_hostname_command() -> Option<String> {
+    use std::process::Command;
+
+    let output = Command::new("hostname").arg("-f").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let fqdn = String::from_utf8(output.stdout).ok()?;
+    let fqdn = fqdn.trim();
+    if fqdn.is_empty() || !fqdn.contains('.') {
+        return None;
+    }
+
+    Some(fqdn.to_string())
+}
+
+fn generate_tee_common_name_from_fqdn(hostname: Option<&str>, uuid: Uuid) -> String {
+    let hostname = hostname
+        .map(sanitize_fqdn_component)
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+    let uuid_simple = uuid.simple().to_string();
+    let suffix = &uuid_simple[..UUID_SUFFIX_HEX_LEN];
+    format!("tee.{}-{}", hostname, suffix)
+}
+
+fn generate_tee_common_name_from_hostname(hostname: Option<&str>, uuid: Uuid) -> String {
+    let hostname = hostname
+        .map(sanitize_hostname_component)
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+    let uuid_simple = uuid.simple().to_string();
+    let suffix = &uuid_simple[..UUID_SUFFIX_HEX_LEN];
+    format!("tas.{}-{}", hostname, suffix)
+}
+
+fn sanitize_hostname_component(hostname: &str) -> String {
+    let mut sanitized = String::with_capacity(hostname.len().min(MAX_HOSTNAME_COMPONENT_LEN));
+    let mut last_was_hyphen = false;
+
+    for ch in hostname.chars().flat_map(char::to_lowercase) {
+        let mapped = if ch.is_ascii_alphanumeric() { ch } else { '-' };
+
+        if mapped == '-' {
+            if sanitized.is_empty() || last_was_hyphen {
+                continue;
+            }
+            last_was_hyphen = true;
+        } else {
+            last_was_hyphen = false;
+        }
+
+        sanitized.push(mapped);
+
+        if sanitized.len() >= MAX_HOSTNAME_COMPONENT_LEN {
+            break;
+        }
+    }
+
+    while sanitized.ends_with('-') {
+        sanitized.pop();
+    }
+
+    sanitized
+}
+
+fn sanitize_fqdn_component(hostname: &str) -> String {
+    let mut sanitized = String::with_capacity(hostname.len().min(MAX_FQDN_COMPONENT_LEN));
+    let mut last_was_separator = false;
+
+    for ch in hostname.chars().flat_map(char::to_lowercase) {
+        let mapped = if ch.is_ascii_alphanumeric() || ch == '.' || ch == '-' {
+            ch
+        } else {
+            '-'
+        };
+
+        if mapped == '-' || mapped == '.' {
+            if sanitized.is_empty() || last_was_separator {
+                continue;
+            }
+            last_was_separator = true;
+        } else {
+            last_was_separator = false;
+        }
+
+        sanitized.push(mapped);
+
+        if sanitized.len() >= MAX_FQDN_COMPONENT_LEN {
+            break;
+        }
+    }
+
+    while sanitized.ends_with('-') || sanitized.ends_with('.') {
+        sanitized.pop();
+    }
+
+    sanitized
+}
+
+pub fn build_plain_csr(key: &AgentKey, common_name: &str) -> Result<String, Box<dyn Error>> {
+    let subject = Name::from_str(&format!("CN={}", common_name))?;
+    let signing_key = key.rsa_4096_signing_key();
+    let verifying_key = signing_key.verifying_key();
+    let public_key = SubjectPublicKeyInfoOwned::from_key(verifying_key)?;
+    let info = CertReqInfo {
+        version: Default::default(),
+        subject,
+        public_key,
+        attributes: Default::default(),
+    };
+    let info_der = info.to_der()?;
+    let signature: Signature = signing_key.sign(&info_der);
+    let csr = CertReq {
+        info,
+        algorithm: signing_key.signature_algorithm_identifier()?,
+        signature: signature.to_bitstring()?,
+    };
+    Ok(csr.to_pem(LineEnding::LF)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rsa::pkcs1v15::VerifyingKey;
+    use rsa::signature::Verifier;
+    use x509_cert::der::{DecodePem, Encode};
+    use x509_cert::request::CertReq;
+    use x509_cert::spki::SubjectPublicKeyInfoRef;
+
+    #[test]
+    fn sanitizes_hostname_component() {
+        assert_eq!(sanitize_hostname_component("CVM_Prod.01"), "cvm-prod-01");
+        assert_eq!(sanitize_hostname_component("---bad///name---"), "bad-name");
+        assert_eq!(sanitize_hostname_component(""), "");
+    }
+
+    #[test]
+    fn sanitizes_fqdn_component() {
+        assert_eq!(
+            sanitize_fqdn_component("Node1.Dev_Prod.Example.Com"),
+            "node1.dev-prod.example.com"
+        );
+        assert_eq!(sanitize_fqdn_component("...bad///name..."), "bad-name");
+    }
+
+    #[test]
+    fn generated_common_name_uses_fqdn_when_available() {
+        let uuid = Uuid::parse_str("3f2a9c14-8b7d-4e21-a9f0-1c2d3e4f5a6b").unwrap();
+        let cn = generate_tee_common_name_from_fqdn(Some("node1.dev.example.com"), uuid);
+        assert_eq!(cn, "tee.node1.dev.example.com-3f2a9c148b7d");
+    }
+
+    #[test]
+    fn generated_common_name_uses_current_scheme_when_not_fqdn() {
+        let uuid = Uuid::parse_str("3f2a9c14-8b7d-4e21-a9f0-1c2d3e4f5a6b").unwrap();
+        let cn = generate_tee_common_name_from_hostname(Some("CVM_Prod.01"), uuid);
+        assert_eq!(cn, "tas.cvm-prod-01-3f2a9c148b7d");
+    }
+
+    #[test]
+    fn generated_common_name_falls_back_to_unknown() {
+        let uuid = Uuid::parse_str("3f2a9c14-8b7d-4e21-a9f0-1c2d3e4f5a6b").unwrap();
+        let cn = generate_tee_common_name_from_hostname(Some("////"), uuid);
+        assert_eq!(cn, "tas.unknown-3f2a9c148b7d");
+    }
+
+    #[test]
+    fn generated_common_names_have_distinct_suffixes() {
+        let first = generate_tee_common_name();
+        let second = generate_tee_common_name();
+        assert_ne!(first, second);
+        assert!(first.starts_with("tee.") || first.starts_with("tas."));
+        assert!(second.starts_with("tee.") || second.starts_with("tas."));
+    }
+
+    #[test]
+    fn builds_plain_pem_csr() {
+        let key = AgentKey::generate(crate::certify::keygen::KeyAlgorithm::Rsa4096).unwrap();
+        let cn = generate_tee_common_name_from_fqdn(
+            Some("node1.dev.example.com"),
+            Uuid::parse_str("3f2a9c14-8b7d-4e21-a9f0-1c2d3e4f5a6b").unwrap(),
+        );
+        let pem = build_plain_csr(&key, &cn).unwrap();
+
+        assert!(pem.starts_with("-----BEGIN CERTIFICATE REQUEST-----"));
+        let csr = CertReq::from_pem(&pem).unwrap();
+        assert!(csr.info.attributes.is_empty());
+        assert!(csr.info.subject.to_string().contains(&cn));
+
+        let public_key_der = csr.info.public_key.to_der().unwrap();
+        let public_key_ref = SubjectPublicKeyInfoRef::try_from(public_key_der.as_slice()).unwrap();
+        let verifying_key = VerifyingKey::<sha2::Sha256>::try_from(public_key_ref).unwrap();
+        let signature = Signature::try_from(csr.signature.raw_bytes()).unwrap();
+        verifying_key
+            .verify(&csr.info.to_der().unwrap(), &signature)
+            .unwrap();
+    }
+}

--- a/src/certify/keygen.rs
+++ b/src/certify/keygen.rs
@@ -1,0 +1,150 @@
+// TEE Attestation Service Agent
+//
+// Copyright 2026 Hewlett Packard Enterprise Development LP.
+// SPDX-License-Identifier: MIT
+//
+// Feature-gated key generation support for the TAS certificate flow.
+
+use rand::rngs::OsRng;
+#[cfg(test)]
+use rsa::pkcs8::EncodePublicKey;
+use rsa::{
+    pkcs1::EncodeRsaPublicKey,
+    pkcs1v15::SigningKey,
+    pkcs8::{DecodePrivateKey, EncodePrivateKey, LineEnding},
+    RsaPrivateKey, RsaPublicKey,
+};
+use sha2::Sha256;
+use std::error::Error;
+
+const RSA_4096_BITS: usize = 4096;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[allow(dead_code)]
+pub enum KeyAlgorithm {
+    #[default]
+    Rsa4096,
+    EccP384,
+}
+
+#[derive(Clone)]
+pub struct AgentKey {
+    public_key: RsaPublicKey,
+    private_key: RsaPrivateKey,
+}
+
+impl AgentKey {
+    pub fn generate(algorithm: KeyAlgorithm) -> Result<Self, Box<dyn Error>> {
+        match algorithm {
+            KeyAlgorithm::Rsa4096 => {
+                let mut rng = OsRng;
+                let private_key = RsaPrivateKey::new(&mut rng, RSA_4096_BITS)?;
+                let public_key = RsaPublicKey::from(&private_key);
+                Ok(Self {
+                    public_key,
+                    private_key,
+                })
+            }
+            KeyAlgorithm::EccP384 => Err("ECC P-384 key generation is not implemented yet".into()),
+        }
+    }
+
+    pub fn from_pkcs8_pem(pem: &str) -> Result<Self, Box<dyn Error>> {
+        let private_key = RsaPrivateKey::from_pkcs8_pem(pem)
+            .map_err(|e| format!("Failed to parse PKCS#8 private key PEM: {}", e))?;
+        let public_key = RsaPublicKey::from(&private_key);
+        Ok(Self {
+            public_key,
+            private_key,
+        })
+    }
+
+    pub fn private_key_to_pkcs8_pem(&self) -> Result<String, Box<dyn Error>> {
+        let pem = self
+            .private_key
+            .to_pkcs8_pem(LineEnding::LF)
+            .map_err(|e| format!("Failed to convert private key to PKCS#8 PEM: {}", e))?;
+        Ok(pem.to_string())
+    }
+
+    pub fn public_key_to_der(&self) -> Result<Vec<u8>, Box<dyn Error>> {
+        let der = self
+            .public_key
+            .to_pkcs1_der()
+            .map_err(|e| format!("Failed to convert public key to DER: {}", e))?;
+        Ok(der.to_vec())
+    }
+
+    #[cfg(test)]
+    fn public_key_to_spki_der(&self) -> Result<Vec<u8>, Box<dyn Error>> {
+        let der = self
+            .public_key
+            .to_public_key_der()
+            .map_err(|e| format!("Failed to convert public key to SPKI DER: {}", e))?;
+        Ok(der.as_bytes().to_vec())
+    }
+
+    pub fn rsa_4096_signing_key(&self) -> SigningKey<Sha256> {
+        SigningKey::<Sha256>::new(self.private_key.clone())
+    }
+
+    #[cfg(test)]
+    fn public_key(&self) -> &RsaPublicKey {
+        &self.public_key
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rsa::pkcs8::DecodePublicKey;
+    use rsa::traits::PublicKeyParts;
+
+    #[test]
+    fn generates_rsa_4096_key() {
+        let key = AgentKey::generate(KeyAlgorithm::Rsa4096).unwrap();
+        assert_eq!(key.public_key().n().bits(), RSA_4096_BITS);
+    }
+
+    #[test]
+    fn exports_pkcs1_public_key_der() {
+        let key = AgentKey::generate(KeyAlgorithm::Rsa4096).unwrap();
+        let der = key.public_key_to_der().unwrap();
+        assert!(!der.is_empty());
+        assert_eq!(der[0], 0x30);
+    }
+
+    #[test]
+    fn exports_spki_public_key_der() {
+        let key = AgentKey::generate(KeyAlgorithm::Rsa4096).unwrap();
+        let spki_der = key.public_key_to_spki_der().unwrap();
+        assert!(!spki_der.is_empty());
+        assert_eq!(spki_der[0], 0x30);
+        RsaPublicKey::from_public_key_der(&spki_der).unwrap();
+        let pkcs1_der = key.public_key_to_der().unwrap();
+        assert_ne!(spki_der, pkcs1_der);
+    }
+
+    #[test]
+    fn private_key_pkcs8_roundtrip_preserves_public_key() {
+        let original = AgentKey::generate(KeyAlgorithm::Rsa4096).unwrap();
+        let pem = original.private_key_to_pkcs8_pem().unwrap();
+        let restored = AgentKey::from_pkcs8_pem(&pem).unwrap();
+
+        assert_eq!(
+            original.public_key_to_spki_der().unwrap(),
+            restored.public_key_to_spki_der().unwrap()
+        );
+    }
+
+    #[test]
+    fn rejects_reserved_ecc_algorithm() {
+        let result = AgentKey::generate(KeyAlgorithm::EccP384);
+        assert!(result.is_err());
+        assert!(result
+            .err()
+            .unwrap()
+            .to_string()
+            .contains("not implemented"));
+    }
+}

--- a/src/certify/material_writer.rs
+++ b/src/certify/material_writer.rs
@@ -1,0 +1,168 @@
+// TEE Attestation Service Agent
+//
+// Copyright 2026 Hewlett Packard Enterprise Development LP.
+// SPDX-License-Identifier: MIT
+//
+// Certificate material writer utilities for certify/renew lifecycle.
+
+use anyhow::{anyhow, Context, Result};
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub const KEY_FILE: &str = "key.pem";
+pub const CERT_FILE: &str = "cert.pem";
+pub const CHAIN_FILE: &str = "chain.pem";
+pub const CA_BUNDLE_FILE: &str = "ca-bundle.pem";
+
+pub fn key_path(dir: &Path) -> PathBuf {
+    dir.join(KEY_FILE)
+}
+
+pub fn cert_path(dir: &Path) -> PathBuf {
+    dir.join(CERT_FILE)
+}
+
+pub fn chain_path(dir: &Path) -> PathBuf {
+    dir.join(CHAIN_FILE)
+}
+
+pub fn ca_bundle_path(dir: &Path) -> PathBuf {
+    dir.join(CA_BUNDLE_FILE)
+}
+
+pub fn write_initial_materials(
+    dir: &Path,
+    key_pem: &str,
+    cert_pem: &str,
+    chain_pem: &str,
+    ca_bundle_pem: &str,
+    force: bool,
+) -> Result<()> {
+    fs::create_dir_all(dir)
+        .with_context(|| format!("failed to create output directory {:?}", dir))?;
+
+    let key_path = key_path(dir);
+    if force {
+        write_atomic(&key_path, key_pem.as_bytes())?;
+    } else {
+        write_create_new(&key_path, key_pem.as_bytes())?;
+    }
+
+    write_atomic(&cert_path(dir), cert_pem.as_bytes())?;
+    write_atomic(&chain_path(dir), chain_pem.as_bytes())?;
+    write_atomic(&ca_bundle_path(dir), ca_bundle_pem.as_bytes())?;
+    Ok(())
+}
+
+pub fn write_renewed_materials(
+    dir: &Path,
+    cert_pem: &str,
+    chain_pem: &str,
+    ca_bundle_pem: &str,
+) -> Result<()> {
+    if !key_path(dir).exists() {
+        return Err(anyhow!(
+            "renewal key file {:?} is missing; run --certify first",
+            key_path(dir)
+        ));
+    }
+
+    fs::create_dir_all(dir)
+        .with_context(|| format!("failed to create output directory {:?}", dir))?;
+    write_atomic(&cert_path(dir), cert_pem.as_bytes())?;
+    write_atomic(&chain_path(dir), chain_pem.as_bytes())?;
+    write_atomic(&ca_bundle_path(dir), ca_bundle_pem.as_bytes())?;
+    Ok(())
+}
+
+fn write_create_new(path: &Path, bytes: &[u8]) -> Result<()> {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .with_context(|| {
+            format!(
+                "refusing to overwrite existing key file {:?}; pass --force to replace it",
+                path
+            )
+        })?;
+    file.write_all(bytes)
+        .with_context(|| format!("failed writing {:?}", path))?;
+    Ok(())
+}
+
+fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow!("path {:?} has no parent directory", path))?;
+    fs::create_dir_all(parent)
+        .with_context(|| format!("failed to create parent directory {:?}", parent))?;
+
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| anyhow!("system time error: {}", e))?
+        .as_nanos();
+    let tmp_path = parent.join(format!(
+        ".{}.{}.tmp",
+        path.file_name().unwrap().to_string_lossy(),
+        nanos
+    ));
+
+    {
+        let mut tmp = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp_path)
+            .with_context(|| format!("failed to create temporary file {:?}", tmp_path))?;
+        tmp.write_all(bytes)
+            .with_context(|| format!("failed writing temporary file {:?}", tmp_path))?;
+        tmp.sync_all()
+            .with_context(|| format!("failed syncing temporary file {:?}", tmp_path))?;
+    }
+
+    fs::rename(&tmp_path, path).with_context(|| {
+        format!(
+            "failed replacing {:?} with temporary file {:?}",
+            path, tmp_path
+        )
+    })?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn writes_initial_materials_and_refuses_key_overwrite_without_force() {
+        let dir = TempDir::new().unwrap();
+        write_initial_materials(dir.path(), "key-1", "cert-1", "chain-1", "ca-1", false).unwrap();
+
+        let err = write_initial_materials(dir.path(), "key-2", "cert-2", "chain-2", "ca-2", false)
+            .unwrap_err();
+        assert!(err.to_string().contains("--force"));
+    }
+
+    #[test]
+    fn renew_updates_cert_materials_but_preserves_key() {
+        let dir = TempDir::new().unwrap();
+        write_initial_materials(dir.path(), "key-1", "cert-1", "chain-1", "ca-1", false).unwrap();
+
+        write_renewed_materials(dir.path(), "cert-2", "chain-2", "ca-2").unwrap();
+
+        assert_eq!(fs::read_to_string(key_path(dir.path())).unwrap(), "key-1");
+        assert_eq!(fs::read_to_string(cert_path(dir.path())).unwrap(), "cert-2");
+        assert_eq!(
+            fs::read_to_string(chain_path(dir.path())).unwrap(),
+            "chain-2"
+        );
+        assert_eq!(
+            fs::read_to_string(ca_bundle_path(dir.path())).unwrap(),
+            "ca-2"
+        );
+    }
+}

--- a/src/certify/mod.rs
+++ b/src/certify/mod.rs
@@ -1,0 +1,365 @@
+// TEE Attestation Service Agent — experimental certify/renew lifecycle.
+//
+// Copyright 2025 -2026 Hewlett Packard Enterprise Development LP.
+// SPDX-License-Identifier: MIT
+//
+// EXPERIMENTAL: the certificate certify/renew lifecycle is gated behind the
+// off-by-default `certify` Cargo feature and is not production-ready. Enabling
+// the feature (`cargo build --features certify`) is the explicit opt-in.
+
+use std::fs::read_to_string;
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Context, Result};
+use clap::Args;
+use log::{debug, warn};
+use serde::Deserialize;
+
+use crate::crypto::compute_report_data_binding;
+use crate::tas_api::{tas_get_version, RetryConfig};
+use crate::tee_evidence::tee_get_evidence;
+use crate::{load_config, Cli, CliOverrides, Config};
+
+mod api;
+mod csr;
+mod keygen;
+mod material_writer;
+mod renewal_input;
+
+use api::{tas_certify, tas_get_alpha_nonce};
+use csr::{build_plain_csr, generate_tee_common_name};
+use keygen::{AgentKey, KeyAlgorithm};
+
+/// Experimental certify/renew command-line flags.
+///
+/// Flattened into the top-level CLI so the flag names (`--certify`, `--renew`,
+/// `--write-dir`, `--force`) and help text live entirely within this module.
+#[derive(Args)]
+pub struct CertifyArgs {
+    /// Generate a plain CSR and bound TEE evidence for the TAS certify flow
+    #[arg(long)]
+    certify: bool,
+
+    /// Renew an existing certificate (requires --write-dir)
+    #[arg(long)]
+    renew: bool,
+
+    /// Directory to write/read certificate materials (key.pem, cert.pem, etc.)
+    #[arg(long, value_name = "DIR")]
+    write_dir: Option<PathBuf>,
+
+    /// Allow overwriting existing key.pem during re-certification
+    #[arg(long)]
+    force: bool,
+}
+
+/// Experimental certify/renew configuration keys.
+///
+/// Flattened into the top-level config so the TOML keys (`certify`, `renew`,
+/// `write_dir`, `force`) stay top-level while their definitions live here.
+#[derive(Deserialize, Default)]
+pub struct CertifyConfig {
+    certify: Option<bool>,
+    renew: Option<bool>,
+    write_dir: Option<PathBuf>,
+    force: Option<bool>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum CertifyMode {
+    Fresh { force: bool },
+    Renew,
+}
+
+/// Pure predicate: is certify/renew mode requested from the resolved inputs?
+fn mode_requested(
+    cli_certify: bool,
+    cli_renew: bool,
+    cfg_certify: Option<bool>,
+    cfg_renew: Option<bool>,
+) -> bool {
+    cli_certify || cli_renew || cfg_certify.unwrap_or(false) || cfg_renew.unwrap_or(false)
+}
+
+/// Whether the user requested certify or renew via CLI flags or config.
+fn certify_mode_requested(cli: &Cli, cfg: &Config) -> bool {
+    let args = &cli.certify_args;
+    let cfg = &cfg.certify_config;
+    mode_requested(args.certify, args.renew, cfg.certify, cfg.renew)
+}
+
+/// Run the certify/renew flow if requested.
+///
+/// Returns `Ok(false)` when certify/renew was not requested (caller continues
+/// with the normal key-fetch flow), `Ok(true)` after the flow handled the run,
+/// and `Err(_)` for input or flow failures (caller logs and exits).
+pub(super) async fn run_if_requested(cli: &Cli, cfg: &Config) -> Result<bool> {
+    if !certify_mode_requested(cli, cfg) {
+        return Ok(false);
+    }
+
+    let args = &cli.certify_args;
+    let cert_cfg = &cfg.certify_config;
+
+    let write_dir = args
+        .write_dir
+        .clone()
+        .or_else(|| cert_cfg.write_dir.clone())
+        .ok_or_else(|| anyhow!("--write-dir is required for --certify or --renew"))?;
+
+    let mode = if args.renew || cert_cfg.renew.unwrap_or(false) {
+        CertifyMode::Renew
+    } else {
+        CertifyMode::Fresh {
+            force: args.force || cert_cfg.force.unwrap_or(false),
+        }
+    };
+
+    let overrides = CliOverrides {
+        server_uri: cli.server_uri.clone(),
+        api_key: cli.api_key.clone(),
+        policy_id: cli.policy_id.clone(),
+        cert_path: cli.cert_path.clone(),
+        max_retries: cli.max_retries,
+        retry_min_backoff_secs: cli.retry_min_backoff_secs,
+        retry_max_backoff_secs: cli.retry_max_backoff_secs,
+    };
+
+    let cert_bundle_pem =
+        certify_flow(cli.config.clone(), Some(overrides), Some(write_dir), mode).await?;
+
+    if cli.debug {
+        use std::io::Write;
+        std::io::stdout()
+            .write_all(cert_bundle_pem.as_bytes())
+            .map_err(|e| anyhow!("failed to write certificate to stdout: {}", e))?;
+    }
+
+    Ok(true)
+}
+
+async fn certify_flow(
+    config_path: Option<PathBuf>,
+    overrides: Option<CliOverrides>,
+    write_dir: Option<PathBuf>,
+    mode: CertifyMode,
+) -> Result<String> {
+    warn!("EXPERIMENTAL: certify/renew lifecycle is not production-ready");
+    let cfg = load_config(config_path)?;
+    let ovr = overrides.unwrap_or(CliOverrides {
+        server_uri: None,
+        api_key: None,
+        policy_id: None,
+        cert_path: None,
+        max_retries: None,
+        retry_min_backoff_secs: None,
+        retry_max_backoff_secs: None,
+    });
+
+    let write_dir = write_dir.ok_or_else(|| anyhow!("write_dir is required"))?;
+
+    //TODO - refactor to share more code with fetch_key(), e.g. config loading, retry config, TAS version check, nonce retrieval, etc.
+
+    let server_uri = ovr
+        .server_uri
+        .or(cfg.server_uri)
+        .ok_or_else(|| anyhow!("server URI is required"))?;
+
+    if !server_uri.starts_with("http://") && !server_uri.starts_with("https://") {
+        return Err(anyhow!(
+            "server URI must start with http:// or https:// (got {:?})",
+            server_uri
+        ));
+    }
+
+    let api_key_path = ovr
+        .api_key
+        .or(cfg.api_key)
+        .unwrap_or_else(|| PathBuf::from("/etc/tas_agent/api-key"));
+
+    let cert_path = ovr
+        .cert_path
+        .or(cfg.cert_path)
+        .unwrap_or_else(|| PathBuf::from("/etc/tas_agent/root_cert.pem"));
+
+    let retry_config = RetryConfig {
+        max_retries: ovr.max_retries.or(cfg.max_retries).unwrap_or(3),
+        min_backoff_secs: ovr
+            .retry_min_backoff_secs
+            .or(cfg.retry_min_backoff_secs)
+            .unwrap_or(1),
+        max_backoff_secs: ovr
+            .retry_max_backoff_secs
+            .or(cfg.retry_max_backoff_secs)
+            .unwrap_or(30),
+    };
+
+    debug!("Retry config: {:?}", retry_config);
+
+    let api_key = read_to_string(api_key_path.clone())
+        .with_context(|| format!("unable to read API key from {:?}", api_key_path))?
+        .trim()
+        .to_string();
+
+    let renew_cert = match mode {
+        CertifyMode::Fresh { force: _ } => None,
+        CertifyMode::Renew => {
+            let cert_str = renewal_input::load_renew_cert_from_dir(&write_dir)
+                .context("failed to load certificate for renewal")?;
+            Some(cert_str)
+        }
+    };
+
+    let agent_key = match mode {
+        CertifyMode::Fresh { force: _ } => {
+            debug!("Certify mode: Fresh");
+            debug!("Generating RSA-4096 certify key (this can take a while in debug builds)...");
+            AgentKey::generate(KeyAlgorithm::Rsa4096)
+                .map_err(|e| anyhow!("failed to generate certify key: {}", e))?
+        }
+        CertifyMode::Renew => {
+            debug!("Certify mode: Renew");
+            let key_pem = renewal_input::load_private_key_from_dir(&write_dir)
+                .context("failed to load private key for renewal")?;
+            AgentKey::from_pkcs8_pem(&key_pem)
+                .map_err(|e| anyhow!("failed to import private key from PKCS#8: {}", e))?
+        }
+    };
+    debug!("Certify key obtained");
+    let common_name = generate_tee_common_name();
+    debug!("Building plain CSR for CN: {}", common_name);
+    let csr_pem = build_plain_csr(&agent_key, &common_name)
+        .map_err(|e| anyhow!("failed to build CSR: {}", e))?;
+    debug!("Generated certify CSR subject CN: {}", common_name);
+
+    match tas_get_version(&server_uri, &api_key, cert_path.clone(), &retry_config).await {
+        Ok(version) => debug!("TEE Attestation Server Version: {}", version),
+        Err(err) => return Err(anyhow!("TAS Version Error: {}", err)),
+    }
+
+    // The alpha API calls this field policy-domain; keep using the existing
+    // policy_id config/CLI name for compatibility with the key-fetch flow.
+    let policy_domain = ovr
+        .policy_id
+        .or(cfg.policy_id)
+        .ok_or_else(|| anyhow!("policy-domain is required for certify flow"))?;
+
+    let nonce = tas_get_alpha_nonce(&server_uri, &api_key, cert_path.clone(), &retry_config)
+        .await
+        .map_err(|e| anyhow!("TAS Alpha Nonce Error: {}", e))?;
+    // Match TAS vm_verify(): report_data binding uses nonce || PKCS#1 public-key DER.
+    let pubkey_der = agent_key
+        .public_key_to_der()
+        .map_err(|e| anyhow!("Failed to get public key DER: {}", e))?;
+    let binding = compute_report_data_binding(nonce.as_bytes(), &pubkey_der);
+    debug!(
+        "Certify report data binding (hex): {}",
+        hex::encode(&binding)
+    );
+
+    let (tee_evidence, tee_type) = tee_get_evidence(&nonce, Some(&binding))
+        .map_err(|err| anyhow!("TEE evidence Error: {}", err))?;
+    debug!(
+        "Generated certify TEE Evidence (Base64-encoded): {}",
+        tee_evidence
+    );
+    debug!("Certify TEE Type: {}", tee_type);
+
+    let issued = tas_certify(
+        &server_uri,
+        &api_key,
+        &nonce,
+        &tee_evidence,
+        &tee_type,
+        renew_cert.as_deref(),
+        &csr_pem,
+        &policy_domain,
+        cert_path,
+        &retry_config,
+        None,
+    )
+    .await
+    .map_err(|e| anyhow!("TAS Certify Error: {}", e))?;
+
+    debug!("Received issued certificate from TAS");
+
+    // Persist certificate materials based on mode
+    match mode {
+        CertifyMode::Fresh { force } => {
+            let key_pem = agent_key
+                .private_key_to_pkcs8_pem()
+                .map_err(|e| anyhow!("failed to serialize key to PKCS#8: {}", e))?;
+            material_writer::write_initial_materials(
+                &write_dir,
+                &key_pem,
+                &issued.certificate,
+                &issued.ca_chain.join(
+                    "
+",
+                ),
+                &issued.ca_chain.join(
+                    "
+",
+                ),
+                force,
+            )
+            .context("failed to write initial certificate materials")?;
+            debug!("Wrote initial certificate materials to {:?}", write_dir);
+        }
+        CertifyMode::Renew => {
+            material_writer::write_renewed_materials(
+                &write_dir,
+                &issued.certificate,
+                &issued.ca_chain.join(
+                    "
+",
+                ),
+                &issued.ca_chain.join(
+                    "
+",
+                ),
+            )
+            .context("failed to write renewed certificate materials")?;
+            debug!("Wrote renewed certificate materials to {:?}", write_dir);
+        }
+    }
+
+    let mut output = issued.certificate;
+    if !issued.ca_chain.is_empty() {
+        output.push('\n');
+        output.push_str(&issued.ca_chain.join("\n"));
+    }
+
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mode_requested;
+
+    #[test]
+    fn mode_requested_none() {
+        assert!(!mode_requested(false, false, None, None));
+        assert!(!mode_requested(false, false, Some(false), Some(false)));
+    }
+
+    #[test]
+    fn mode_requested_cli_certify() {
+        assert!(mode_requested(true, false, None, None));
+    }
+
+    #[test]
+    fn mode_requested_cli_renew() {
+        assert!(mode_requested(false, true, None, None));
+    }
+
+    #[test]
+    fn mode_requested_cfg_certify() {
+        assert!(mode_requested(false, false, Some(true), None));
+    }
+
+    #[test]
+    fn mode_requested_cfg_renew() {
+        assert!(mode_requested(false, false, None, Some(true)));
+    }
+}

--- a/src/certify/renewal_input.rs
+++ b/src/certify/renewal_input.rs
@@ -1,0 +1,63 @@
+// TEE Attestation Service Agent
+//
+// Copyright 2026 Hewlett Packard Enterprise Development LP.
+// SPDX-License-Identifier: MIT
+//
+// Renewal input loading and framing checks.
+
+use crate::certify::material_writer::{cert_path, key_path};
+use anyhow::{anyhow, Context, Result};
+use std::fs;
+use std::path::Path;
+
+pub fn load_renew_cert_from_dir(write_dir: &Path) -> Result<String> {
+    let path = cert_path(write_dir);
+    let cert_pem = fs::read_to_string(&path)
+        .with_context(|| format!("failed to read renewal certificate {:?}", path))?;
+    validate_leaf_cert_pem_framing(&cert_pem)?;
+    Ok(cert_pem)
+}
+
+pub fn load_private_key_from_dir(write_dir: &Path) -> Result<String> {
+    let path = key_path(write_dir);
+    fs::read_to_string(&path)
+        .with_context(|| format!("failed to read renewal private key {:?}", path))
+}
+
+pub fn validate_leaf_cert_pem_framing(cert_pem: &str) -> Result<()> {
+    let trimmed = cert_pem.trim();
+    if trimmed.is_empty() {
+        return Err(anyhow!("renew_cert PEM is empty"));
+    }
+
+    if !trimmed.starts_with("-----BEGIN CERTIFICATE-----") {
+        return Err(anyhow!(
+            "renew_cert PEM must start with BEGIN CERTIFICATE block"
+        ));
+    }
+
+    if !trimmed.ends_with("-----END CERTIFICATE-----") {
+        return Err(anyhow!(
+            "renew_cert PEM must end with END CERTIFICATE block"
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_basic_leaf_certificate_framing() {
+        let pem = "-----BEGIN CERTIFICATE-----\nZmFrZQo=\n-----END CERTIFICATE-----\n";
+        assert!(validate_leaf_cert_pem_framing(pem).is_ok());
+    }
+
+    #[test]
+    fn rejects_empty_or_invalid_framing() {
+        assert!(validate_leaf_cert_pem_framing("").is_err());
+        assert!(validate_leaf_cert_pem_framing("-----BEGIN FOO-----").is_err());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,8 @@ use std::path::PathBuf;
 mod askpass;
 mod crypto;
 // Any component feature
+#[cfg(feature = "certify")]
+mod certify;
 #[cfg(feature = "gpu-nvidia")]
 mod components;
 #[cfg(feature = "passfifo")]
@@ -68,6 +70,10 @@ struct Cli {
     /// Display debugging messages
     #[arg(short, long)]
     debug: bool,
+
+    #[cfg(feature = "certify")]
+    #[command(flatten)]
+    certify_args: certify::CertifyArgs,
 
     /// Path to the config file (default: '/etc/tas_agent/config.toml')
     #[arg(short, long, value_name = "FILE")]
@@ -131,6 +137,9 @@ struct Config {
     // Any GPU feature
     #[cfg(feature = "gpu-nvidia")]
     no_gpu: Option<bool>,
+    #[cfg(feature = "certify")]
+    #[serde(flatten)]
+    certify_config: certify::CertifyConfig,
     /// Enable systemd ask-password watcher mode
     #[cfg(feature = "askpass")]
     askpass: Option<bool>,
@@ -430,7 +439,24 @@ async fn main() {
         }
     }
 
-    // --- Normal (stdout) mode ---
+    #[cfg(feature = "certify")]
+    {
+        let cfg = match load_config(cli.config.clone()) {
+            Ok(cfg) => cfg,
+            Err(e) => {
+                eprintln!("{:#}", e);
+                std::process::exit(1);
+            }
+        };
+        match certify::run_if_requested(&cli, &cfg).await {
+            Ok(true) => return,
+            Ok(false) => {}
+            Err(e) => {
+                eprintln!("{:#}", e);
+                std::process::exit(1);
+            }
+        }
+    }
     let overrides = CliOverrides {
         server_uri: cli.server_uri,
         api_key: cli.api_key,

--- a/src/tas_api.rs
+++ b/src/tas_api.rs
@@ -44,7 +44,7 @@ impl Default for RetryConfig {
 /// When `server_uri` uses `https://`, the cert bundle at `cert_path` is loaded and added
 /// as trusted root certificates. For plain `http://` URIs the cert file is skipped,
 /// which avoids failures in initrd environments that lack a CA bundle.
-fn create_client(
+pub(crate) fn create_client(
     server_uri: &str,
     cert_path: PathBuf,
     retry_config: &RetryConfig,


### PR DESCRIPTION
This commit introduces the feature-gated experimental `certify` flow, allowing the agent to request and retrieve X.509 certificates from the TAS `/alphav1/certify` endpoint.

This is the first attempt and is experimental and not ready for production.

The certify flow generates a PKCS#10 CSR using the FQDN or the hostname with a random suffix as the CSR Common Name.

It adds flags `certify` to request a new certificate and `renew` to renew a non-expired one. Both modes need the flag `write-dir` for writing and reading keys and certs.

Most of the certify code is in its own module so that it can be easy to change code without affecting the more stable parts of the code base. When adding further code, try as much as possible to contain any certify code in the certify module so that the certify feature, which is very experimental, will be isolated as much as possible from the rest of the code.