### PR TITLE
feat(certify): make certify a subcommand; support CSR SANs and custom CN

### DIFF
--- a/config/config.toml.sample
+++ b/config/config.toml.sample
@@ -26,10 +26,6 @@ policy_id = "..."
 # Maximum backoff time in seconds between retries (default: 30)
 # retry_max_backoff_secs = 30
 
-# Enable certificate CSR generation mode
-# (requires the 'certify' feature to be enabled at build time)
-# certify = false
-
 # Enable systemd ask-password watcher mode for automatic LUKS unlock
 # (requires the 'askpass' feature to be enabled at build time)
 # askpass = false

--- a/docs/experimental/certify.md
+++ b/docs/experimental/certify.md
@@ -18,19 +18,23 @@ key.
 
 Two lifecycle operations are supported:
 
-- **Initial certification** (`--certify`): generates a fresh RSA-4096 key,
+- **Initial certification** (`certify`): generates a fresh RSA-4096 key,
   builds a CSR, gathers TEE evidence, and requests a new certificate.
-- **Renewal** (`--renew`): reuses the previously generated private key and the
-  previously issued certificate to request a refreshed certificate.
+- **Renewal** (`certify --renew`): reuses the previously generated private key
+  and the previously issued certificate to request a refreshed certificate.
 
-The agent sets the CSR subject Common Name (CN) from the host's identity: it
-uses the host's fully-qualified domain name (FQDN) when one is available, and
-otherwise falls back to the short hostname. A short random suffix is appended to
-the CN.
+By default the agent sets the CSR subject Common Name (CN) from the host's
+identity: it uses the host's fully-qualified domain name (FQDN) when one is
+available, and otherwise falls back to the short hostname, with a short random
+suffix appended. The CN can be overridden with `--common-name` (alias `--cn`) or
+the `common_name` config key. Optional Subject Alternative Names may be requested
+with repeatable `--san TYPE:VALUE` flags or the `sans` config key; both apply
+identically to initial certification and renewal.
 
 The certificate identity (SPIFFE ID / UUID) is minted server-side by TAS. The
-agent's CSR only contributes the public key and this CN; the agent never asserts
-its own identity.
+agent's CSR only contributes the public key, CN, and any requested SANs; the
+agent never asserts its own identity, and TAS remains authoritative over what it
+signs.
 
 ## Building
 
@@ -57,22 +61,23 @@ All certify/renew code lives under the feature-gated `src/certify/` module and
 is compiled only with `--features certify`. The rest of the codebase contains no
 certify-specific logic, so the feature can be developed in isolation:
 
-- `src/certify/mod.rs` — flow orchestration (`certify_flow`), CLI/config
-  dispatch (`run_if_requested`), the experimental runtime warning, and the
+- `src/certify/mod.rs` — flow orchestration (`certify_flow`), the `certify`
+  subcommand entry point (`run`), the experimental runtime warning, and the
   `CertifyArgs` / `CertifyConfig` structs that define the certify CLI flags and
   config keys.
 - `src/certify/api.rs` — certify/renew TAS REST calls (`tas_certify`,
   `tas_get_alpha_nonce`) and their request/response payload types.
 - `src/certify/keygen.rs` — RSA-4096 key generation.
-- `src/certify/csr.rs` — CSR construction and Common Name derivation.
+- `src/certify/csr.rs` — CSR construction, Common Name derivation, and SAN/CN
+  parsing and validation (`parse_san`, `parse_common_name`).
 - `src/certify/material_writer.rs` — atomic on-disk material writes.
 - `src/certify/renewal_input.rs` — loading existing key/cert for renewal.
 
-The certify CLI flags and config keys are defined as `CertifyArgs` /
-`CertifyConfig` inside the module and flattened (`#[command(flatten)]` /
-`#[serde(flatten)]`) into the top-level `Cli` / `Config` in `src/main.rs`. The
-flag names (`--certify`, `--renew`, `--write-dir`, `--force`) and TOML keys stay
-identical; only their definitions moved into the module.
+The certify flow is exposed as the `certify` subcommand: `CertifyArgs` is the
+subcommand body (`Commands::Certify` in `src/main.rs`) and `CertifyConfig` is
+flattened (`#[serde(flatten)]`) into the top-level `Config` to supply defaults.
+Shared connection flags (`--server-uri`, `--policy-id`, ...) are global, so they
+may appear before or after the `certify` token.
 
 The core `src/tas_api.rs` holds only the non-experimental endpoints. The certify
 API in `src/certify/api.rs` reuses its `pub(crate)` `create_client` helper, so
@@ -89,14 +94,17 @@ EXPERIMENTAL: certify/renew lifecycle is not production-ready
 
 ## Command-line flags
 
-The following flags are only available when compiled with `--features certify`:
+The certify flow is invoked as a subcommand: `tas_agent certify [OPTIONS]`. The
+following flags are available on the `certify` subcommand (only when compiled
+with `--features certify`):
 
 | Flag | Argument | Description |
 | --- | --- | --- |
-| `--certify` | _(none)_ | Initial certification mode. Generates a new key and requests a certificate. |
-| `--renew` | _(none)_ | Renewal mode. Reuses the existing key and certificate from `--write-dir`. |
-| `--write-dir <DIR>` | directory | **Required** for `--certify` and `--renew`. Directory where key/certificate materials are written and read. |
+| `--renew` | _(none)_ | Renewal mode. Reuses the existing key and certificate from `--write-dir`. Without it, `certify` performs initial certification. |
+| `--write-dir <DIR>` | directory | **Required.** Directory where key/certificate materials are written and read. |
 | `--force` | _(none)_ | Allow overwriting an existing `key.pem` during initial certification. |
+| `--common-name <CN>`, `--cn` | string | Override the CSR subject Common Name (default: auto-generated). Max 64 chars; RFC 4514 DN metacharacters and control characters are rejected. |
+| `--san <TYPE:VALUE>` | repeatable | Request a Subject Alternative Name. `TYPE` is one of `DNS`, `IP`, `URI`, `email` (case-insensitive). Overrides the `sans` config key when given. |
 
 These shared flags also apply:
 
@@ -114,21 +122,23 @@ These shared flags also apply:
 
 ## Configuration file
 
-The lifecycle flags may also be set in the TOML config file instead of (or in
-addition to) the command line. CLI flags take precedence over config values.
+Config keys supply defaults for the `certify` subcommand; CLI flags take
+precedence over config values. The mode is always chosen with the `certify`
+subcommand and its command-line options.
 
 ```toml
-# Enable certificate certification mode
-certify = true
-
-# Enable renewal mode (mutually exclusive intent with certify; renew takes priority)
-# renew = true
-
 # Directory for certificate materials (equivalent to --write-dir)
 write_dir = "/var/lib/tas_agent/certs"
 
-# Allow overwriting an existing key.pem during certification
+# Allow overwriting an existing key.pem during initial certification
 # force = false
+
+# Override the CSR subject Common Name (default: auto-generated)
+# common_name = "tee.host.example.com"
+
+# Subject Alternative Names to request (OpenSSL TYPE:VALUE form). A --san flag on
+# the command line overrides this list. Applied for both fresh and renew.
+# sans = ["DNS:host.example.com", "IP:10.0.0.1", "URI:spiffe://td/workload"]
 ```
 
 The existing `server_uri`, `api_key`, `policy_id`, `cert_path`, and retry
@@ -161,7 +171,7 @@ write directory.
 ```bash
 sudo target/debug/tas_agent -d \
   -c ~/config.toml \
-  --certify \
+  certify \
   --write-dir /var/lib/tas_agent/certs
 ```
 
@@ -170,8 +180,19 @@ To overwrite an existing `key.pem` (re-certify from scratch), add `--force`:
 ```bash
 sudo target/debug/tas_agent -d \
   -c ~/config.toml \
-  --certify --force \
+  certify --force \
   --write-dir /var/lib/tas_agent/certs
+```
+
+To set a custom Common Name and request Subject Alternative Names:
+
+```bash
+sudo target/debug/tas_agent -d \
+  -c ~/config.toml \
+  certify \
+  --write-dir /var/lib/tas_agent/certs \
+  --common-name tee.web.example.com \
+  --san DNS:web.example.com --san IP:10.0.0.1 --san URI:spiffe://td/workload
 ```
 
 ### Renewal
@@ -183,7 +204,7 @@ a refreshed certificate, and atomically updates `cert.pem`, `chain.pem`, and
 ```bash
 sudo target/debug/tas_agent -d \
   -c ~/config.toml \
-  --renew \
+  certify --renew \
   --write-dir /var/lib/tas_agent/certs
 ```
 

--- a/src/certify/csr.rs
+++ b/src/certify/csr.rs
@@ -9,10 +9,15 @@ use crate::certify::keygen::AgentKey;
 use rsa::pkcs1v15::Signature;
 use rsa::signature::{Keypair, Signer};
 use std::error::Error;
+use std::net::IpAddr;
 use std::str::FromStr;
 use uuid::Uuid;
+use x509_cert::builder::{Builder, RequestBuilder};
+use x509_cert::der::asn1::{Ia5String, OctetString};
 use x509_cert::der::pem::LineEnding;
 use x509_cert::der::{Encode, EncodePem};
+use x509_cert::ext::pkix::name::GeneralName;
+use x509_cert::ext::pkix::SubjectAltName;
 use x509_cert::name::Name;
 use x509_cert::request::{CertReq, CertReqInfo};
 use x509_cert::spki::{
@@ -22,6 +27,107 @@ use x509_cert::spki::{
 const MAX_FQDN_COMPONENT_LEN: usize = 47;
 const MAX_HOSTNAME_COMPONENT_LEN: usize = 32;
 const UUID_SUFFIX_HEX_LEN: usize = 12;
+
+/// Maximum length of a Common Name value (X.509 `ub-common-name`, RFC 5280).
+const MAX_COMMON_NAME_LEN: usize = 64;
+
+/// Maximum number of Subject Alternative Names accepted for a single CSR.
+const MAX_SANS: usize = 64;
+
+/// A single Subject Alternative Name requested for the CSR.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SanEntry {
+    /// `dNSName` general name.
+    Dns(String),
+    /// `iPAddress` general name.
+    Ip(IpAddr),
+    /// `uniformResourceIdentifier` general name.
+    Uri(String),
+    /// `rfc822Name` (email address) general name.
+    Email(String),
+}
+
+/// Parses a `TYPE:VALUE` Subject Alternative Name token.
+///
+/// Accepts the OpenSSL-style type tokens `DNS`, `IP`, `URI`, and `email`
+/// (case-insensitive). The token is split on the first `:` so that IPv6
+/// addresses and URIs containing colons are preserved.
+///
+/// # Errors
+///
+/// Returns an error string if the token has no `:`, an empty value, an
+/// unsupported type, a value containing whitespace, a non-ASCII value for the
+/// IA5String-encoded types, or an unparseable IP address.
+pub fn parse_san(s: &str) -> Result<SanEntry, String> {
+    let (kind, value) = s
+        .split_once(':')
+        .ok_or_else(|| format!("invalid SAN {s:?}, expected TYPE:VALUE"))?;
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(format!("invalid SAN {s:?}: empty value"));
+    }
+    if value.chars().any(char::is_whitespace) {
+        return Err(format!(
+            "invalid SAN {s:?}: value must not contain whitespace"
+        ));
+    }
+    match kind.trim().to_ascii_lowercase().as_str() {
+        "dns" => {
+            ensure_ascii(value, "DNS")?;
+            Ok(SanEntry::Dns(value.to_string()))
+        }
+        "uri" => {
+            ensure_ascii(value, "URI")?;
+            Ok(SanEntry::Uri(value.to_string()))
+        }
+        "email" => {
+            ensure_ascii(value, "email")?;
+            Ok(SanEntry::Email(value.to_string()))
+        }
+        "ip" => value
+            .parse::<IpAddr>()
+            .map(SanEntry::Ip)
+            .map_err(|e| format!("invalid IP in SAN {s:?}: {e}")),
+        other => Err(format!(
+            "unsupported SAN type {other:?} (expected dns|ip|uri|email)"
+        )),
+    }
+}
+
+fn ensure_ascii(value: &str, label: &str) -> Result<(), String> {
+    if value.is_ascii() {
+        Ok(())
+    } else {
+        Err(format!("{label} SAN must be ASCII (IA5String): {value:?}"))
+    }
+}
+
+/// Validates a user-supplied Common Name for safe use in the CSR subject.
+///
+/// The value is trimmed and must be non-empty, at most [`MAX_COMMON_NAME_LEN`]
+/// characters, and free of RFC 4514 distinguished-name metacharacters and
+/// control characters so that it cannot inject additional relative
+/// distinguished names into the subject.
+///
+/// # Errors
+///
+/// Returns an error string describing the first validation failure.
+pub fn parse_common_name(s: &str) -> Result<String, String> {
+    let cn = s.trim();
+    if cn.is_empty() {
+        return Err("common name must not be empty".to_string());
+    }
+    if cn.chars().count() > MAX_COMMON_NAME_LEN {
+        return Err(format!(
+            "common name exceeds {MAX_COMMON_NAME_LEN} characters"
+        ));
+    }
+    const FORBIDDEN: &[char] = &[',', '+', '=', '"', '\\', '<', '>', ';', '#'];
+    if let Some(bad) = cn.chars().find(|c| c.is_control() || FORBIDDEN.contains(c)) {
+        return Err(format!("common name contains forbidden character {bad:?}"));
+    }
+    Ok(cn.to_string())
+}
 
 pub fn generate_tee_common_name() -> String {
     let uuid = Uuid::new_v4();
@@ -151,24 +257,72 @@ fn sanitize_fqdn_component(hostname: &str) -> String {
     sanitized
 }
 
-pub fn build_plain_csr(key: &AgentKey, common_name: &str) -> Result<String, Box<dyn Error>> {
-    let subject = Name::from_str(&format!("CN={}", common_name))?;
+fn to_general_names(sans: &[SanEntry]) -> Result<Vec<GeneralName>, Box<dyn Error>> {
+    sans.iter()
+        .map(|san| {
+            Ok(match san {
+                SanEntry::Dns(v) => GeneralName::DnsName(Ia5String::new(v)?),
+                SanEntry::Uri(v) => GeneralName::UniformResourceIdentifier(Ia5String::new(v)?),
+                SanEntry::Email(v) => GeneralName::Rfc822Name(Ia5String::new(v)?),
+                SanEntry::Ip(ip) => {
+                    let octets: Vec<u8> = match ip {
+                        IpAddr::V4(a) => a.octets().to_vec(),
+                        IpAddr::V6(a) => a.octets().to_vec(),
+                    };
+                    GeneralName::IpAddress(OctetString::new(octets)?)
+                }
+            })
+        })
+        .collect()
+}
+
+/// Builds a signed PKCS#10 certificate signing request in PEM form.
+///
+/// When `sans` is empty the request is constructed directly with empty
+/// attributes, preserving the historical byte-for-byte output (no
+/// `extensionRequest` attribute). When one or more SANs are supplied a
+/// `SubjectAltName` extension is added via the request builder.
+///
+/// # Errors
+///
+/// Returns an error if more than [`MAX_SANS`] SANs are requested, if a SAN
+/// value cannot be encoded, or if CSR construction, signing, or PEM encoding
+/// fails.
+pub fn build_plain_csr(
+    key: &AgentKey,
+    common_name: &str,
+    sans: &[SanEntry],
+) -> Result<String, Box<dyn Error>> {
+    if sans.len() > MAX_SANS {
+        return Err(format!("too many SANs: {} (max {MAX_SANS})", sans.len()).into());
+    }
+
+    let subject = Name::from_str(&format!("CN={common_name}"))?;
     let signing_key = key.rsa_4096_signing_key();
-    let verifying_key = signing_key.verifying_key();
-    let public_key = SubjectPublicKeyInfoOwned::from_key(verifying_key)?;
-    let info = CertReqInfo {
-        version: Default::default(),
-        subject,
-        public_key,
-        attributes: Default::default(),
-    };
-    let info_der = info.to_der()?;
-    let signature: Signature = signing_key.sign(&info_der);
-    let csr = CertReq {
-        info,
-        algorithm: signing_key.signature_algorithm_identifier()?,
-        signature: signature.to_bitstring()?,
-    };
+
+    if sans.is_empty() {
+        let verifying_key = signing_key.verifying_key();
+        let public_key = SubjectPublicKeyInfoOwned::from_key(verifying_key)?;
+        let info = CertReqInfo {
+            version: Default::default(),
+            subject,
+            public_key,
+            attributes: Default::default(),
+        };
+        let info_der = info.to_der()?;
+        let signature: Signature = signing_key.sign(&info_der);
+        let csr = CertReq {
+            info,
+            algorithm: signing_key.signature_algorithm_identifier()?,
+            signature: signature.to_bitstring()?,
+        };
+        return Ok(csr.to_pem(LineEnding::LF)?);
+    }
+
+    let general_names = to_general_names(sans)?;
+    let mut builder = RequestBuilder::new(subject, &signing_key)?;
+    builder.add_extension(&SubjectAltName(general_names))?;
+    let csr = builder.build::<Signature>()?;
     Ok(csr.to_pem(LineEnding::LF)?)
 }
 
@@ -180,6 +334,10 @@ mod tests {
     use x509_cert::der::{DecodePem, Encode};
     use x509_cert::request::CertReq;
     use x509_cert::spki::SubjectPublicKeyInfoRef;
+
+    fn contains_subslice(haystack: &[u8], needle: &[u8]) -> bool {
+        haystack.windows(needle.len()).any(|w| w == needle)
+    }
 
     #[test]
     fn sanitizes_hostname_component() {
@@ -228,13 +386,59 @@ mod tests {
     }
 
     #[test]
+    fn parse_san_accepts_each_type() {
+        assert_eq!(
+            parse_san("DNS:web.example.com").unwrap(),
+            SanEntry::Dns("web.example.com".to_string())
+        );
+        assert_eq!(
+            parse_san("uri:spiffe://td/x").unwrap(),
+            SanEntry::Uri("spiffe://td/x".to_string())
+        );
+        assert_eq!(
+            parse_san("Email:a@example.com").unwrap(),
+            SanEntry::Email("a@example.com".to_string())
+        );
+        assert_eq!(
+            parse_san("IP:10.0.0.1").unwrap(),
+            SanEntry::Ip("10.0.0.1".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn parse_san_handles_ipv6_first_colon_split() {
+        assert_eq!(
+            parse_san("IP:2001:db8::1").unwrap(),
+            SanEntry::Ip("2001:db8::1".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn parse_san_rejects_bad_inputs() {
+        assert!(parse_san("nocolon").is_err());
+        assert!(parse_san("DNS:").is_err());
+        assert!(parse_san("IP:not-an-ip").is_err());
+        assert!(parse_san("FOO:bar").is_err());
+        assert!(parse_san("DNS:has space").is_err());
+    }
+
+    #[test]
+    fn parse_common_name_validates() {
+        assert_eq!(parse_common_name("  tee.node  ").unwrap(), "tee.node");
+        assert!(parse_common_name("").is_err());
+        assert!(parse_common_name("evil,O=other").is_err());
+        assert!(parse_common_name("a=b").is_err());
+        assert!(parse_common_name(&"x".repeat(65)).is_err());
+    }
+
+    #[test]
     fn builds_plain_pem_csr() {
         let key = AgentKey::generate(crate::certify::keygen::KeyAlgorithm::Rsa4096).unwrap();
         let cn = generate_tee_common_name_from_fqdn(
             Some("node1.dev.example.com"),
             Uuid::parse_str("3f2a9c14-8b7d-4e21-a9f0-1c2d3e4f5a6b").unwrap(),
         );
-        let pem = build_plain_csr(&key, &cn).unwrap();
+        let pem = build_plain_csr(&key, &cn, &[]).unwrap();
 
         assert!(pem.starts_with("-----BEGIN CERTIFICATE REQUEST-----"));
         let csr = CertReq::from_pem(&pem).unwrap();
@@ -248,5 +452,53 @@ mod tests {
         verifying_key
             .verify(&csr.info.to_der().unwrap(), &signature)
             .unwrap();
+    }
+
+    #[test]
+    fn builds_csr_with_sans_embeds_values_and_verifies() {
+        let key = AgentKey::generate(crate::certify::keygen::KeyAlgorithm::Rsa4096).unwrap();
+        let sans = vec![
+            SanEntry::Dns("web.example.com".to_string()),
+            SanEntry::Uri("spiffe://td/x".to_string()),
+            SanEntry::Ip("10.0.0.1".parse().unwrap()),
+        ];
+        let pem = build_plain_csr(&key, "tee.test", &sans).unwrap();
+        let csr = CertReq::from_pem(&pem).unwrap();
+
+        assert!(!csr.info.attributes.is_empty());
+
+        let der = csr.info.to_der().unwrap();
+        assert!(contains_subslice(&der, b"web.example.com"));
+        assert!(contains_subslice(&der, b"spiffe://td/x"));
+        assert!(contains_subslice(&der, &[10u8, 0, 0, 1]));
+
+        let public_key_der = csr.info.public_key.to_der().unwrap();
+        let public_key_ref = SubjectPublicKeyInfoRef::try_from(public_key_der.as_slice()).unwrap();
+        let verifying_key = VerifyingKey::<sha2::Sha256>::try_from(public_key_ref).unwrap();
+        let signature = Signature::try_from(csr.signature.raw_bytes()).unwrap();
+        verifying_key
+            .verify(&csr.info.to_der().unwrap(), &signature)
+            .unwrap();
+    }
+
+    #[test]
+    fn builds_csr_with_multiple_same_type_sans() {
+        let key = AgentKey::generate(crate::certify::keygen::KeyAlgorithm::Rsa4096).unwrap();
+        let sans = vec![
+            SanEntry::Ip("10.0.0.1".parse().unwrap()),
+            SanEntry::Ip("10.0.0.2".parse().unwrap()),
+            SanEntry::Dns("a.example.com".to_string()),
+            SanEntry::Dns("b.example.com".to_string()),
+        ];
+        let pem = build_plain_csr(&key, "tee.test", &sans).unwrap();
+        let csr = CertReq::from_pem(&pem).unwrap();
+        let der = csr.info.to_der().unwrap();
+
+        // Both IP-type SANs are present (encoded as raw 4-octet addresses).
+        assert!(contains_subslice(&der, &[10u8, 0, 0, 1]));
+        assert!(contains_subslice(&der, &[10u8, 0, 0, 2]));
+        // Both DNS-type SANs are present.
+        assert!(contains_subslice(&der, b"a.example.com"));
+        assert!(contains_subslice(&der, b"b.example.com"));
     }
 }

--- a/src/certify/mod.rs
+++ b/src/certify/mod.rs
@@ -27,19 +27,12 @@ mod material_writer;
 mod renewal_input;
 
 use api::{tas_certify, tas_get_alpha_nonce};
-use csr::{build_plain_csr, generate_tee_common_name};
+use csr::{build_plain_csr, generate_tee_common_name, parse_common_name, parse_san, SanEntry};
 use keygen::{AgentKey, KeyAlgorithm};
 
-/// Experimental certify/renew command-line flags.
-///
-/// Flattened into the top-level CLI so the flag names (`--certify`, `--renew`,
-/// `--write-dir`, `--force`) and help text live entirely within this module.
+/// Experimental certify/renew command-line flags for the `certify` subcommand.
 #[derive(Args)]
 pub struct CertifyArgs {
-    /// Generate a plain CSR and bound TEE evidence for the TAS certify flow
-    #[arg(long)]
-    certify: bool,
-
     /// Renew an existing certificate (requires --write-dir)
     #[arg(long)]
     renew: bool,
@@ -51,18 +44,27 @@ pub struct CertifyArgs {
     /// Allow overwriting existing key.pem during re-certification
     #[arg(long)]
     force: bool,
+
+    /// Subject Common Name for the CSR (default: auto-generated from hostname/UUID)
+    #[arg(long = "common-name", visible_alias = "cn", value_name = "CN", value_parser = parse_common_name)]
+    common_name: Option<String>,
+
+    /// Subject Alternative Name to request; repeatable. Format: TYPE:VALUE
+    /// where TYPE is one of DNS, IP, URI, email (e.g. --san DNS:host.example.com)
+    #[arg(long = "san", value_name = "TYPE:VALUE", value_parser = parse_san)]
+    sans: Vec<SanEntry>,
 }
 
-/// Experimental certify/renew configuration keys.
+/// Experimental certify configuration keys.
 ///
-/// Flattened into the top-level config so the TOML keys (`certify`, `renew`,
-/// `write_dir`, `force`) stay top-level while their definitions live here.
+/// Flattened into the top-level config so the TOML keys (`write_dir`, `force`,
+/// `common_name`, `sans`) stay top-level while their definitions live here.
 #[derive(Deserialize, Default)]
 pub struct CertifyConfig {
-    certify: Option<bool>,
-    renew: Option<bool>,
     write_dir: Option<PathBuf>,
     force: Option<bool>,
+    common_name: Option<String>,
+    sans: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -71,48 +73,58 @@ enum CertifyMode {
     Renew,
 }
 
-/// Pure predicate: is certify/renew mode requested from the resolved inputs?
-fn mode_requested(
-    cli_certify: bool,
-    cli_renew: bool,
-    cfg_certify: Option<bool>,
-    cfg_renew: Option<bool>,
-) -> bool {
-    cli_certify || cli_renew || cfg_certify.unwrap_or(false) || cfg_renew.unwrap_or(false)
-}
-
-/// Whether the user requested certify or renew via CLI flags or config.
-fn certify_mode_requested(cli: &Cli, cfg: &Config) -> bool {
-    let args = &cli.certify_args;
-    let cfg = &cfg.certify_config;
-    mode_requested(args.certify, args.renew, cfg.certify, cfg.renew)
-}
-
-/// Run the certify/renew flow if requested.
+/// Runs the certify/renew flow for the `certify` subcommand.
 ///
-/// Returns `Ok(false)` when certify/renew was not requested (caller continues
-/// with the normal key-fetch flow), `Ok(true)` after the flow handled the run,
-/// and `Err(_)` for input or flow failures (caller logs and exits).
-pub(super) async fn run_if_requested(cli: &Cli, cfg: &Config) -> Result<bool> {
-    if !certify_mode_requested(cli, cfg) {
-        return Ok(false);
-    }
-
-    let args = &cli.certify_args;
+/// Resolves the write directory, mode, common name, and SANs from the CLI
+/// arguments and config (CLI overrides config), then performs the certify or
+/// renew flow. In debug mode the issued certificate bundle is written to stdout.
+///
+/// # Errors
+///
+/// Returns an error for missing required inputs, invalid common name or SAN
+/// values, or any failure in the certify flow.
+pub(super) async fn run(cli: &Cli, args: &CertifyArgs, cfg: &Config) -> Result<()> {
     let cert_cfg = &cfg.certify_config;
 
     let write_dir = args
         .write_dir
         .clone()
         .or_else(|| cert_cfg.write_dir.clone())
-        .ok_or_else(|| anyhow!("--write-dir is required for --certify or --renew"))?;
+        .ok_or_else(|| anyhow!("--write-dir is required for the certify command"))?;
 
-    let mode = if args.renew || cert_cfg.renew.unwrap_or(false) {
+    let mode = if args.renew {
         CertifyMode::Renew
     } else {
         CertifyMode::Fresh {
             force: args.force || cert_cfg.force.unwrap_or(false),
         }
+    };
+
+    // Common name: CLI overrides config; validated here. None => auto-generated
+    // in the certify flow, preserving the historical default behaviour.
+    let common_name = match args
+        .common_name
+        .clone()
+        .or_else(|| cert_cfg.common_name.clone())
+    {
+        Some(cn) => {
+            Some(parse_common_name(&cn).map_err(|e| anyhow!("invalid common name: {}", e))?)
+        }
+        None => None,
+    };
+
+    // SANs: CLI overrides config (replace). Config strings are validated the
+    // same way as CLI values via parse_san. Applied identically for fresh and
+    // renew, so a configured SAN set is stable across renewals.
+    let sans: Vec<SanEntry> = if !args.sans.is_empty() {
+        args.sans.clone()
+    } else if let Some(cfg_sans) = &cert_cfg.sans {
+        cfg_sans
+            .iter()
+            .map(|s| parse_san(s).map_err(|e| anyhow!("invalid SAN in config: {}", e)))
+            .collect::<Result<Vec<_>>>()?
+    } else {
+        Vec::new()
     };
 
     let overrides = CliOverrides {
@@ -125,8 +137,15 @@ pub(super) async fn run_if_requested(cli: &Cli, cfg: &Config) -> Result<bool> {
         retry_max_backoff_secs: cli.retry_max_backoff_secs,
     };
 
-    let cert_bundle_pem =
-        certify_flow(cli.config.clone(), Some(overrides), Some(write_dir), mode).await?;
+    let cert_bundle_pem = certify_flow(
+        cli.config.clone(),
+        Some(overrides),
+        Some(write_dir),
+        mode,
+        common_name,
+        sans,
+    )
+    .await?;
 
     if cli.debug {
         use std::io::Write;
@@ -135,7 +154,7 @@ pub(super) async fn run_if_requested(cli: &Cli, cfg: &Config) -> Result<bool> {
             .map_err(|e| anyhow!("failed to write certificate to stdout: {}", e))?;
     }
 
-    Ok(true)
+    Ok(())
 }
 
 async fn certify_flow(
@@ -143,6 +162,8 @@ async fn certify_flow(
     overrides: Option<CliOverrides>,
     write_dir: Option<PathBuf>,
     mode: CertifyMode,
+    common_name: Option<String>,
+    sans: Vec<SanEntry>,
 ) -> Result<String> {
     warn!("EXPERIMENTAL: certify/renew lifecycle is not production-ready");
     let cfg = load_config(config_path)?;
@@ -226,9 +247,9 @@ async fn certify_flow(
         }
     };
     debug!("Certify key obtained");
-    let common_name = generate_tee_common_name();
+    let common_name = common_name.unwrap_or_else(generate_tee_common_name);
     debug!("Building plain CSR for CN: {}", common_name);
-    let csr_pem = build_plain_csr(&agent_key, &common_name)
+    let csr_pem = build_plain_csr(&agent_key, &common_name, &sans)
         .map_err(|e| anyhow!("failed to build CSR: {}", e))?;
     debug!("Generated certify CSR subject CN: {}", common_name);
 
@@ -293,14 +314,8 @@ async fn certify_flow(
                 &write_dir,
                 &key_pem,
                 &issued.certificate,
-                &issued.ca_chain.join(
-                    "
-",
-                ),
-                &issued.ca_chain.join(
-                    "
-",
-                ),
+                &issued.ca_chain.join("\n"),
+                &issued.ca_chain.join("\n"),
                 force,
             )
             .context("failed to write initial certificate materials")?;
@@ -310,14 +325,8 @@ async fn certify_flow(
             material_writer::write_renewed_materials(
                 &write_dir,
                 &issued.certificate,
-                &issued.ca_chain.join(
-                    "
-",
-                ),
-                &issued.ca_chain.join(
-                    "
-",
-                ),
+                &issued.ca_chain.join("\n"),
+                &issued.ca_chain.join("\n"),
             )
             .context("failed to write renewed certificate materials")?;
             debug!("Wrote renewed certificate materials to {:?}", write_dir);
@@ -331,35 +340,4 @@ async fn certify_flow(
     }
 
     Ok(output)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::mode_requested;
-
-    #[test]
-    fn mode_requested_none() {
-        assert!(!mode_requested(false, false, None, None));
-        assert!(!mode_requested(false, false, Some(false), Some(false)));
-    }
-
-    #[test]
-    fn mode_requested_cli_certify() {
-        assert!(mode_requested(true, false, None, None));
-    }
-
-    #[test]
-    fn mode_requested_cli_renew() {
-        assert!(mode_requested(false, true, None, None));
-    }
-
-    #[test]
-    fn mode_requested_cfg_certify() {
-        assert!(mode_requested(false, false, Some(true), None));
-    }
-
-    #[test]
-    fn mode_requested_cfg_renew() {
-        assert!(mode_requested(false, false, None, Some(true)));
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ mod tas_api;
 mod tee_evidence;
 mod utils;
 use anyhow::{anyhow, Context, Result};
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use serde::Deserialize;
 
 use crypto::{
@@ -68,49 +68,45 @@ impl log::Log for SimpleLogger {
 #[command(author, version, about, long_about = None)]
 struct Cli {
     /// Display debugging messages
-    #[arg(short, long)]
+    #[arg(short, long, global = true)]
     debug: bool,
 
-    #[cfg(feature = "certify")]
-    #[command(flatten)]
-    certify_args: certify::CertifyArgs,
-
     /// Path to the config file (default: '/etc/tas_agent/config.toml')
-    #[arg(short, long, value_name = "FILE")]
+    #[arg(short, long, value_name = "FILE", global = true)]
     config: Option<PathBuf>,
 
     /// The URI of the TAS REST service
-    #[arg(long, value_name = "URI")]
+    #[arg(long, value_name = "URI", global = true)]
     server_uri: Option<String>,
 
     /// Path to the API key for the TAS REST service
-    #[arg(long, value_name = "FILE")]
+    #[arg(long, value_name = "FILE", global = true)]
     api_key: Option<PathBuf>,
 
     /// Policy ID to request from the TAS REST service
-    #[arg(long, value_name = "ID")]
+    #[arg(long, value_name = "ID", global = true)]
     policy_id: Option<String>,
 
     /// Path to the CA root certificate signing the TAS REST service cert
-    #[arg(long, value_name = "FILE")]
+    #[arg(long, value_name = "FILE", global = true)]
     cert_path: Option<PathBuf>,
 
     /// Maximum number of retry attempts for HTTP requests (default: 3)
-    #[arg(long, value_name = "N")]
+    #[arg(long, value_name = "N", global = true)]
     max_retries: Option<u32>,
 
     /// Minimum backoff time in seconds between retries (default: 1)
-    #[arg(long, value_name = "SECS")]
+    #[arg(long, value_name = "SECS", global = true)]
     retry_min_backoff_secs: Option<u64>,
 
     /// Maximum backoff time in seconds between retries (default: 30)
-    #[arg(long, value_name = "SECS")]
+    #[arg(long, value_name = "SECS", global = true)]
     retry_max_backoff_secs: Option<u64>,
 
     /// Disable GPU attestation (enabled by default when built with GPU support)
     // Any GPU feature
     #[cfg(feature = "gpu-nvidia")]
-    #[arg(long)]
+    #[arg(long, global = true)]
     no_gpu: bool,
 
     /// Enable systemd ask-password watcher mode for automatic LUKS unlock
@@ -122,6 +118,22 @@ struct Cli {
     #[cfg(feature = "passfifo")]
     #[arg(long)]
     passfifo: bool,
+
+    /// Subcommand to run; when omitted the agent performs the default key fetch.
+    #[command(subcommand)]
+    #[allow(dead_code)]
+    command: Option<Commands>,
+}
+
+/// Top-level subcommands.
+#[derive(Subcommand)]
+enum Commands {
+    /// Fetch and unwrap a secret key (default when no subcommand is given)
+    Fetch,
+
+    /// Obtain or renew an attestation-bound certificate (EXPERIMENTAL)
+    #[cfg(feature = "certify")]
+    Certify(certify::CertifyArgs),
 }
 
 #[derive(Deserialize, Default)]
@@ -440,7 +452,7 @@ async fn main() {
     }
 
     #[cfg(feature = "certify")]
-    {
+    if let Some(Commands::Certify(args)) = &cli.command {
         let cfg = match load_config(cli.config.clone()) {
             Ok(cfg) => cfg,
             Err(e) => {
@@ -448,14 +460,11 @@ async fn main() {
                 std::process::exit(1);
             }
         };
-        match certify::run_if_requested(&cli, &cfg).await {
-            Ok(true) => return,
-            Ok(false) => {}
-            Err(e) => {
-                eprintln!("{:#}", e);
-                std::process::exit(1);
-            }
+        if let Err(e) = certify::run(&cli, args, &cfg).await {
+            eprintln!("{:#}", e);
+            std::process::exit(1);
         }
+        return;
     }
     let overrides = CliOverrides {
         server_uri: cli.server_uri,


### PR DESCRIPTION
Make certify more useful by allowing users to specify SANs to add to the CSR, as well as a custom Common Name. Note that a user can specify any SAN they want, including a URI SAN, but it is up to the server whether to include them.

This commit makes a deliberate design decision not to strip URI SANs, so that it is easy to verify that the TAS server is actually ignoring them.