### PR TITLE
feat(certify): enable GPU attestation and CI tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,8 @@ env:
 
 jobs:
   # ---------------------------------------------------------------------------
-  # Feature matrix: check + test each feature combination
+  # Feature matrix: Cargo features are additive, 
+  # so we test the default build and a build with all features enabled.
   # ---------------------------------------------------------------------------
   feature-matrix:
     runs-on: ubuntu-latest
@@ -20,23 +21,19 @@ jobs:
       matrix:
         features:
           - ""
-          - "askpass"
-          - "passfifo"
-          - "askpass,passfifo"
+          - "certify,askpass,passfifo"
     steps:
     - uses: actions/checkout@v3
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: stable
-
-    - name: Cargo check
-      run: cargo check ${{ matrix.features && format('--features {0}', matrix.features) }}
+    - uses: Swatinem/rust-cache@v2
 
     - name: Cargo test
-      run: cargo test ${{ matrix.features && format('--features {0}', matrix.features) }}
+      run: cargo test --all-targets ${{ matrix.features && format('--features {0}', matrix.features) }}
 
   # ---------------------------------------------------------------------------
-  # Full build + docs (all features enabled)
+  # Static checks, release build, docs, and distribution build.
   # ---------------------------------------------------------------------------
   rust-checks:
     runs-on: ubuntu-latest
@@ -46,21 +43,28 @@ jobs:
       with:
         toolchain: stable
         components: rustfmt, clippy
+    - uses: Swatinem/rust-cache@v2
 
-    - name: Build debug
-      run: cargo build --features askpass,passfifo
+    - name: Check formatting
+      run: cargo fmt --check
+
+    - name: Check isolated features
+      run: |
+        cargo check --features askpass
+        cargo check --features passfifo
+        cargo check --features certify
+
+    - name: Run clippy
+      run: cargo clippy --all-targets --features certify,askpass,passfifo -- -D warnings
 
     - name: Build release
-      run: cargo build --release --features askpass,passfifo
-
-    - name: Run tests (debug)
-      run: cargo test --features askpass,passfifo
+      run: cargo build --release --features certify,askpass,passfifo
 
     - name: Run tests (release)
-      run: cargo test --release --features askpass,passfifo
+      run: cargo test --release --all-targets --features certify,askpass,passfifo
 
     - name: Build docs
-      run: cargo doc --no-deps --features askpass,passfifo
+      run: cargo doc --no-deps --features certify,askpass,passfifo
 
     - name: Build via script
       run: |
@@ -78,6 +82,7 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: stable
+    - uses: Swatinem/rust-cache@v2
 
     - name: Install packaging deps
       run: sudo apt-get update && sudo apt-get install -y dpkg-dev debhelper fakeroot pkg-config libssl-dev
@@ -103,6 +108,7 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: stable
+    - uses: Swatinem/rust-cache@v2
 
     - name: Install packaging deps
       run: sudo apt-get update && sudo apt-get install -y rpm pkg-config libssl-dev
@@ -141,23 +147,37 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: stable
+    - uses: Swatinem/rust-cache@v2
 
     # System packages needed to build the C++ SDK and generate Rust bindings.
-    # The SDK statically builds OpenSSL/curl/xmlsec itself, so we only need the
-    # toolchain, libclang (bindgen), and libxml2/zlib (found via find_package).
+    # CI uses the SDK's supported system-dependency mode to avoid rebuilding
+    # OpenSSL, curl, and xmlsec from source on every cold cache.
     - name: Install SDK build dependencies
       run: |
         sudo apt-get update
         sudo apt-get install -y \
           build-essential cmake pkg-config git perl \
           clang libclang-dev \
+          libssl-dev libcurl4-openssl-dev libxmlsec1-dev \
           libxml2-dev zlib1g-dev
+
+    - name: Identify runner image
+      id: runner-image
+      run: echo "image=${ImageOS:-unknown}-${ImageVersion:-unknown}" >> "$GITHUB_OUTPUT"
+
+    - name: Restore libnvat cache
+      id: libnvat-cache
+      uses: actions/cache@v4
+      with:
+        path: .cache/libnvat-install
+        key: libnvat-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-image.outputs.image }}-${{ hashFiles('Cargo.toml', '.github/workflows/tests.yml') }}
 
     # Build libnvat from the exact git tag referenced in Cargo.toml so the ABI
     # matches the crate the `gpu-nvidia` feature pulls in, then install it to
     # /usr so the sys-crate's NVAT_USE_SYSTEM_LIB mode finds /usr/include/nvat.h
     # and /usr/lib/libnvat.so.
     - name: Build and install libnvat (NVIDIA Attestation SDK)
+      if: steps.libnvat-cache.outputs.cache-hit != 'true'
       # Allow warnings for the SDK build only, due to warnings from SDK dependencies
       env:
         RUSTFLAGS: "-A warnings"
@@ -170,6 +190,7 @@ jobs:
         cmake -S /tmp/attestation-sdk/nv-attestation-sdk-cpp -B /tmp/attestation-sdk/build \
           -DCMAKE_BUILD_TYPE=Release \
           -DBUILD_SHARED_LIBS=ON \
+          -DUSE_SYSTEM_DEPS=ON \
           -DCMAKE_INSTALL_PREFIX=/usr \
           -DCMAKE_INSTALL_LIBDIR=lib \
           -DCMAKE_BUILD_PARALLEL_LEVEL="$(nproc)"
@@ -177,15 +198,14 @@ jobs:
           echo "::warning::Parallel SDK build failed; retrying serially to surface the real error"
           cmake --build /tmp/attestation-sdk/build -j1 --verbose
         fi
-        sudo cmake --install /tmp/attestation-sdk/build
-        sudo ldconfig
+        DESTDIR="$PWD/.cache/libnvat-install" cmake --install /tmp/attestation-sdk/build
 
-    - name: Cargo check (gpu-nvidia)
-      env:
-        NVAT_USE_SYSTEM_LIB: "1"
-      run: cargo check --features gpu-nvidia,askpass,passfifo
+    - name: Install libnvat
+      run: |
+        sudo cp -a .cache/libnvat-install/usr/. /usr/
+        sudo ldconfig
 
     - name: Cargo test (gpu-nvidia)
       env:
         NVAT_USE_SYSTEM_LIB: "1"
-      run: cargo test --features gpu-nvidia,askpass,passfifo
+      run: cargo test --all-targets --features gpu-nvidia,certify,askpass,passfifo

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ debian
 tas-agent-tests/
 tas_agent_tests/
 testing/
+
+#Ignore Nvidia GPU SDK artifacts
+attestation-sdk/

--- a/docs/experimental/certify.md
+++ b/docs/experimental/certify.md
@@ -47,6 +47,9 @@ cargo build --features certify
 
 # Release build
 cargo build --release --features certify
+
+# Release build with NVIDIA GPU attestation
+NVAT_USE_SYSTEM_LIB=1 cargo build --release --features certify,gpu-nvidia
 ```
 
 The resulting binary is at `target/debug/tas_agent` (or
@@ -67,6 +70,8 @@ certify-specific logic, so the feature can be developed in isolation:
   config keys.
 - `src/certify/api.rs` — certify/renew TAS REST calls (`tas_certify`,
   `tas_get_alpha_nonce`) and their request/response payload types.
+- `src/certify/gpu.rs` — certify-specific adaptation of NVIDIA evidence to the
+  `gpu-evidence` API payload.
 - `src/certify/keygen.rs` — RSA-4096 key generation.
 - `src/certify/csr.rs` — CSR construction, Common Name derivation, and SAN/CN
   parsing and validation (`parse_san`, `parse_common_name`).
@@ -119,6 +124,7 @@ These shared flags also apply:
 | `--max-retries <N>` | integer | Maximum HTTP retry attempts (default: 3). |
 | `--retry-min-backoff-secs <SECS>` | integer | Minimum retry backoff in seconds (default: 1). |
 | `--retry-max-backoff-secs <SECS>` | integer | Maximum retry backoff in seconds (default: 30). |
+| `--no-gpu` | _(none)_ | Disable GPU attestation in a `certify,gpu-nvidia` build. |
 
 ## Configuration file
 
@@ -143,6 +149,20 @@ write_dir = "/var/lib/tas_agent/certs"
 
 The existing `server_uri`, `api_key`, `policy_id`, `cert_path`, and retry
 settings are shared with the normal key-fetch flow.
+
+## GPU attestation
+
+When built with both `certify` and `gpu-nvidia`, GPU attestation is enabled by
+default for initial certification and renewal. The agent collects up to 16
+NVIDIA GPU evidence entries and submits them as the certify API's bare
+`gpu-evidence` array. It binds their ordered SHA-512 hashes into the CPU TEE
+report data together with the nonce and certificate public key.
+
+GPU collection is fail-closed: collection, payload validation, or attestation
+failure stops the certify operation before certificate material is written.
+Use `--no-gpu` or `no_gpu = true` in `config.toml` for CPU-only certification.
+This opt-out does not override TAS policy; a policy requiring GPU components
+rejects a CPU-only request.
 
 ## On-disk file layout
 
@@ -238,6 +258,8 @@ openssl x509 -in /var/lib/tas_agent/certs/cert.pem -noout -serial
 - A CA root certificate for validating the TAS service certificate (for HTTPS).
 - The host must be able to produce TEE evidence (e.g., running inside a
   supported confidential VM).
+- GPU-enabled certification additionally requires `libnvat`, a supported
+  NVIDIA GPU, and a TAS policy compatible with the submitted GPU evidence.
 
 ## Limitations
 

--- a/src/certify/api.rs
+++ b/src/certify/api.rs
@@ -37,7 +37,7 @@ struct CertifyRequest<'a> {
     #[serde(skip_serializing_if = "Option::is_none", rename = "renew_cert")]
     renew_cert: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "gpu-evidence")]
-    gpu_evidence: Option<&'a serde_json::Value>,
+    gpu_evidence: Option<&'a [serde_json::Value]>,
 }
 
 pub async fn tas_get_alpha_nonce(
@@ -92,7 +92,7 @@ pub async fn tas_certify(
     policy_domain: &str,
     cert_path: PathBuf,
     retry_config: &RetryConfig,
-    gpu_evidence: Option<&serde_json::Value>,
+    gpu_evidence: Option<&[serde_json::Value]>,
 ) -> Result<CertifyResponse, String> {
     let certify_url = format!("{}/alphav1/certify", server_uri);
     let client = create_client(server_uri, cert_path, retry_config)?;
@@ -305,6 +305,66 @@ CzWyyc0J/7PWdmvFVgXukRznKqZp/d4xAaQIKxLcxGwwDNp1
 
         assert!(result.certificate.contains("BEGIN CERTIFICATE"));
         assert_eq!(result.ca_chain.len(), 1);
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_tas_certify_sends_gpu_evidence_as_bare_array() {
+        let csr_der = CertReq::from_pem(sample_csr_pem())
+            .unwrap()
+            .to_der()
+            .unwrap();
+        let expected_csr_b64 = general_purpose::STANDARD.encode(csr_der);
+        let gpu_evidence = vec![
+            serde_json::json!({
+                "type": "gpu-nvidia",
+                "device-index": 0,
+                "evidence": "gpu-zero"
+            }),
+            serde_json::json!({
+                "type": "gpu-nvidia",
+                "device-index": 1,
+                "evidence": "gpu-one"
+            }),
+        ];
+        let expected_body = serde_json::json!({
+            "tee-type": "amd-sev-snp",
+            "nonce": "nonce123",
+            "tee-evidence": "dGVzdC1ldmlkZW5jZQ==",
+            "csr": expected_csr_b64,
+            "policy-domain": "tenant-a",
+            "gpu-evidence": gpu_evidence,
+        })
+        .to_string();
+
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("POST", "/alphav1/certify")
+            .match_body(mockito::Matcher::JsonString(expected_body))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"certificate":"leaf","ca_chain":[]}"#)
+            .create_async()
+            .await;
+
+        let cert_file = create_test_cert();
+        let result = tas_certify(
+            &server.url(),
+            "key",
+            "nonce123",
+            "dGVzdC1ldmlkZW5jZQ==",
+            "amd-sev-snp",
+            None,
+            sample_csr_pem(),
+            "tenant-a",
+            cert_file.path().to_path_buf(),
+            &no_retry_config(),
+            Some(&gpu_evidence),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.certificate, "leaf");
         mock.assert_async().await;
     }
 

--- a/src/certify/gpu.rs
+++ b/src/certify/gpu.rs
@@ -1,0 +1,114 @@
+// TEE Attestation Service Agent
+//
+// Copyright 2026 Hewlett Packard Enterprise Development LP.
+// SPDX-License-Identifier: MIT
+//
+// GPU component evidence collection for certify requests.
+
+use anyhow::{anyhow, Context, Result};
+use serde_json::Value;
+
+const MAX_GPU_EVIDENCE_ENTRIES: usize = 16;
+const SHA512_DIGEST_LEN: usize = 64;
+
+/// Collects GPU evidence for a certify request.
+///
+/// # Errors
+///
+/// Returns an error when NVIDIA evidence collection fails or the collector
+/// returns a malformed, empty, oversized, or inconsistent payload.
+pub(super) fn collect(nonce_hex: &str) -> Result<(Vec<Value>, Vec<u8>)> {
+    let (payload, hashes) = crate::components::gpu_nvidia::collect_and_hash_gpu_evidence(nonce_hex)
+        .map_err(anyhow::Error::msg)
+        .context("failed to collect GPU evidence for certify")?;
+    let entries = extract_gpu_entries(payload)?;
+    let expected_hash_bytes = entries.len() * SHA512_DIGEST_LEN;
+
+    if hashes.len() != expected_hash_bytes {
+        return Err(anyhow!(
+            "GPU evidence hash chain has {} bytes for {} entries; expected {}",
+            hashes.len(),
+            entries.len(),
+            expected_hash_bytes
+        ));
+    }
+
+    Ok((entries, hashes))
+}
+
+fn extract_gpu_entries(mut payload: Value) -> Result<Vec<Value>> {
+    let gpu = payload
+        .get_mut("gpu")
+        .ok_or_else(|| anyhow!("GPU evidence payload is missing the 'gpu' field"))?
+        .take();
+    let entries = gpu
+        .as_array()
+        .cloned()
+        .ok_or_else(|| anyhow!("GPU evidence payload field 'gpu' must be an array"))?;
+
+    if entries.is_empty() {
+        return Err(anyhow!("GPU evidence payload contains no entries"));
+    }
+    if entries.len() > MAX_GPU_EVIDENCE_ENTRIES {
+        return Err(anyhow!(
+            "GPU evidence payload contains {} entries; maximum is {}",
+            entries.len(),
+            MAX_GPU_EVIDENCE_ENTRIES
+        ));
+    }
+
+    Ok(entries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn payload_with_entries(count: usize) -> Value {
+        json!({
+            "gpu": (0..count)
+                .map(|index| json!({
+                    "type": "gpu-nvidia",
+                    "device-index": index,
+                    "evidence": "evidence"
+                }))
+                .collect::<Vec<_>>()
+        })
+    }
+
+    #[test]
+    fn extracts_bare_gpu_array() {
+        let entries = extract_gpu_entries(payload_with_entries(2)).unwrap();
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0]["device-index"], 0);
+        assert_eq!(entries[1]["device-index"], 1);
+    }
+
+    #[test]
+    fn rejects_missing_non_array_and_empty_gpu_payloads() {
+        let missing = extract_gpu_entries(json!({})).unwrap_err();
+        assert!(missing.to_string().contains("missing the 'gpu' field"));
+
+        let non_array = extract_gpu_entries(json!({ "gpu": {} })).unwrap_err();
+        assert!(non_array.to_string().contains("must be an array"));
+
+        let empty = extract_gpu_entries(payload_with_entries(0)).unwrap_err();
+        assert!(empty.to_string().contains("contains no entries"));
+    }
+
+    #[test]
+    fn enforces_backend_gpu_limit() {
+        assert_eq!(
+            extract_gpu_entries(payload_with_entries(MAX_GPU_EVIDENCE_ENTRIES))
+                .unwrap()
+                .len(),
+            MAX_GPU_EVIDENCE_ENTRIES
+        );
+
+        let error =
+            extract_gpu_entries(payload_with_entries(MAX_GPU_EVIDENCE_ENTRIES + 1)).unwrap_err();
+        assert!(error.to_string().contains("maximum is 16"));
+    }
+}

--- a/src/certify/mod.rs
+++ b/src/certify/mod.rs
@@ -16,12 +16,16 @@ use log::{debug, warn};
 use serde::Deserialize;
 
 use crate::crypto::compute_report_data_binding;
+#[cfg(feature = "gpu-nvidia")]
+use crate::crypto::compute_report_data_binding_with_components;
 use crate::tas_api::{tas_get_version, RetryConfig};
 use crate::tee_evidence::tee_get_evidence;
-use crate::{load_config, Cli, CliOverrides, Config};
+use crate::{Cli, Config};
 
 mod api;
 mod csr;
+#[cfg(feature = "gpu-nvidia")]
+mod gpu;
 mod keygen;
 mod material_writer;
 mod renewal_input;
@@ -71,6 +75,90 @@ pub struct CertifyConfig {
 enum CertifyMode {
     Fresh { force: bool },
     Renew,
+}
+
+struct CertifySettings {
+    server_uri: String,
+    api_key_path: PathBuf,
+    policy_domain: String,
+    cert_path: PathBuf,
+    retry_config: RetryConfig,
+    #[cfg(feature = "gpu-nvidia")]
+    gpu_enabled: bool,
+}
+
+impl CertifySettings {
+    fn resolve(cli: &Cli, cfg: &Config) -> Result<Self> {
+        let server_uri = cli
+            .server_uri
+            .clone()
+            .or_else(|| cfg.server_uri.clone())
+            .ok_or_else(|| anyhow!("server URI is required"))?;
+
+        if !server_uri.starts_with("http://") && !server_uri.starts_with("https://") {
+            return Err(anyhow!(
+                "server URI must start with http:// or https:// (got {:?})",
+                server_uri
+            ));
+        }
+
+        let api_key_path = cli
+            .api_key
+            .clone()
+            .or_else(|| cfg.api_key.clone())
+            .unwrap_or_else(|| PathBuf::from("/etc/tas_agent/api-key"));
+        let policy_domain = cli
+            .policy_id
+            .clone()
+            .or_else(|| cfg.policy_id.clone())
+            .ok_or_else(|| anyhow!("policy-domain is required for certify flow"))?;
+        let cert_path = cli
+            .cert_path
+            .clone()
+            .or_else(|| cfg.cert_path.clone())
+            .unwrap_or_else(|| PathBuf::from("/etc/tas_agent/root_cert.pem"));
+        let retry_config = RetryConfig {
+            max_retries: cli.max_retries.or(cfg.max_retries).unwrap_or(3),
+            min_backoff_secs: cli
+                .retry_min_backoff_secs
+                .or(cfg.retry_min_backoff_secs)
+                .unwrap_or(1),
+            max_backoff_secs: cli
+                .retry_max_backoff_secs
+                .or(cfg.retry_max_backoff_secs)
+                .unwrap_or(30),
+        };
+
+        Ok(Self {
+            server_uri,
+            api_key_path,
+            policy_domain,
+            cert_path,
+            retry_config,
+            #[cfg(feature = "gpu-nvidia")]
+            gpu_enabled: !cli.no_gpu && !cfg.no_gpu.unwrap_or(false),
+        })
+    }
+}
+
+fn certify_report_data(
+    nonce: &str,
+    public_key_pkcs1_der: &[u8],
+    component_hashes: &[u8],
+) -> Vec<u8> {
+    #[cfg(feature = "gpu-nvidia")]
+    if !component_hashes.is_empty() {
+        return compute_report_data_binding_with_components(
+            nonce.as_bytes(),
+            public_key_pkcs1_der,
+            component_hashes,
+        );
+    }
+
+    #[cfg(not(feature = "gpu-nvidia"))]
+    debug_assert!(component_hashes.is_empty());
+
+    compute_report_data_binding(nonce.as_bytes(), public_key_pkcs1_der)
 }
 
 /// Runs the certify/renew flow for the `certify` subcommand.
@@ -127,25 +215,9 @@ pub(super) async fn run(cli: &Cli, args: &CertifyArgs, cfg: &Config) -> Result<(
         Vec::new()
     };
 
-    let overrides = CliOverrides {
-        server_uri: cli.server_uri.clone(),
-        api_key: cli.api_key.clone(),
-        policy_id: cli.policy_id.clone(),
-        cert_path: cli.cert_path.clone(),
-        max_retries: cli.max_retries,
-        retry_min_backoff_secs: cli.retry_min_backoff_secs,
-        retry_max_backoff_secs: cli.retry_max_backoff_secs,
-    };
+    let settings = CertifySettings::resolve(cli, cfg)?;
 
-    let cert_bundle_pem = certify_flow(
-        cli.config.clone(),
-        Some(overrides),
-        Some(write_dir),
-        mode,
-        common_name,
-        sans,
-    )
-    .await?;
+    let cert_bundle_pem = certify_flow(settings, write_dir, mode, common_name, sans).await?;
 
     if cli.debug {
         use std::io::Write;
@@ -158,67 +230,17 @@ pub(super) async fn run(cli: &Cli, args: &CertifyArgs, cfg: &Config) -> Result<(
 }
 
 async fn certify_flow(
-    config_path: Option<PathBuf>,
-    overrides: Option<CliOverrides>,
-    write_dir: Option<PathBuf>,
+    settings: CertifySettings,
+    write_dir: PathBuf,
     mode: CertifyMode,
     common_name: Option<String>,
     sans: Vec<SanEntry>,
 ) -> Result<String> {
     warn!("EXPERIMENTAL: certify/renew lifecycle is not production-ready");
-    let cfg = load_config(config_path)?;
-    let ovr = overrides.unwrap_or(CliOverrides {
-        server_uri: None,
-        api_key: None,
-        policy_id: None,
-        cert_path: None,
-        max_retries: None,
-        retry_min_backoff_secs: None,
-        retry_max_backoff_secs: None,
-    });
+    debug!("Retry config: {:?}", settings.retry_config);
 
-    let write_dir = write_dir.ok_or_else(|| anyhow!("write_dir is required"))?;
-
-    //TODO - refactor to share more code with fetch_key(), e.g. config loading, retry config, TAS version check, nonce retrieval, etc.
-
-    let server_uri = ovr
-        .server_uri
-        .or(cfg.server_uri)
-        .ok_or_else(|| anyhow!("server URI is required"))?;
-
-    if !server_uri.starts_with("http://") && !server_uri.starts_with("https://") {
-        return Err(anyhow!(
-            "server URI must start with http:// or https:// (got {:?})",
-            server_uri
-        ));
-    }
-
-    let api_key_path = ovr
-        .api_key
-        .or(cfg.api_key)
-        .unwrap_or_else(|| PathBuf::from("/etc/tas_agent/api-key"));
-
-    let cert_path = ovr
-        .cert_path
-        .or(cfg.cert_path)
-        .unwrap_or_else(|| PathBuf::from("/etc/tas_agent/root_cert.pem"));
-
-    let retry_config = RetryConfig {
-        max_retries: ovr.max_retries.or(cfg.max_retries).unwrap_or(3),
-        min_backoff_secs: ovr
-            .retry_min_backoff_secs
-            .or(cfg.retry_min_backoff_secs)
-            .unwrap_or(1),
-        max_backoff_secs: ovr
-            .retry_max_backoff_secs
-            .or(cfg.retry_max_backoff_secs)
-            .unwrap_or(30),
-    };
-
-    debug!("Retry config: {:?}", retry_config);
-
-    let api_key = read_to_string(api_key_path.clone())
-        .with_context(|| format!("unable to read API key from {:?}", api_key_path))?
+    let api_key = read_to_string(settings.api_key_path.clone())
+        .with_context(|| format!("unable to read API key from {:?}", settings.api_key_path))?
         .trim()
         .to_string();
 
@@ -253,26 +275,42 @@ async fn certify_flow(
         .map_err(|e| anyhow!("failed to build CSR: {}", e))?;
     debug!("Generated certify CSR subject CN: {}", common_name);
 
-    match tas_get_version(&server_uri, &api_key, cert_path.clone(), &retry_config).await {
+    match tas_get_version(
+        &settings.server_uri,
+        &api_key,
+        settings.cert_path.clone(),
+        &settings.retry_config,
+    )
+    .await
+    {
         Ok(version) => debug!("TEE Attestation Server Version: {}", version),
         Err(err) => return Err(anyhow!("TAS Version Error: {}", err)),
     }
 
-    // The alpha API calls this field policy-domain; keep using the existing
-    // policy_id config/CLI name for compatibility with the key-fetch flow.
-    let policy_domain = ovr
-        .policy_id
-        .or(cfg.policy_id)
-        .ok_or_else(|| anyhow!("policy-domain is required for certify flow"))?;
-
-    let nonce = tas_get_alpha_nonce(&server_uri, &api_key, cert_path.clone(), &retry_config)
-        .await
-        .map_err(|e| anyhow!("TAS Alpha Nonce Error: {}", e))?;
+    let nonce = tas_get_alpha_nonce(
+        &settings.server_uri,
+        &api_key,
+        settings.cert_path.clone(),
+        &settings.retry_config,
+    )
+    .await
+    .map_err(|e| anyhow!("TAS Alpha Nonce Error: {}", e))?;
     // Match TAS vm_verify(): report_data binding uses nonce || PKCS#1 public-key DER.
     let pubkey_der = agent_key
         .public_key_to_der()
         .map_err(|e| anyhow!("Failed to get public key DER: {}", e))?;
-    let binding = compute_report_data_binding(nonce.as_bytes(), &pubkey_der);
+
+    #[cfg(feature = "gpu-nvidia")]
+    let (gpu_evidence, component_hashes) = if settings.gpu_enabled {
+        let (entries, hashes) = gpu::collect(&nonce)?;
+        (Some(entries), hashes)
+    } else {
+        (None, Vec::new())
+    };
+    #[cfg(not(feature = "gpu-nvidia"))]
+    let component_hashes = Vec::new();
+
+    let binding = certify_report_data(&nonce, &pubkey_der, &component_hashes);
     debug!(
         "Certify report data binding (hex): {}",
         hex::encode(&binding)
@@ -287,16 +325,19 @@ async fn certify_flow(
     debug!("Certify TEE Type: {}", tee_type);
 
     let issued = tas_certify(
-        &server_uri,
+        &settings.server_uri,
         &api_key,
         &nonce,
         &tee_evidence,
         &tee_type,
         renew_cert.as_deref(),
         &csr_pem,
-        &policy_domain,
-        cert_path,
-        &retry_config,
+        &settings.policy_domain,
+        settings.cert_path,
+        &settings.retry_config,
+        #[cfg(feature = "gpu-nvidia")]
+        gpu_evidence.as_deref(),
+        #[cfg(not(feature = "gpu-nvidia"))]
         None,
     )
     .await
@@ -340,4 +381,177 @@ async fn certify_flow(
     }
 
     Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    fn parse_cli(args: &[&str]) -> Cli {
+        let mut all_args = vec!["tas_agent"];
+        all_args.extend_from_slice(args);
+        Cli::try_parse_from(all_args).unwrap()
+    }
+
+    #[test]
+    fn certify_settings_cli_overrides_config() {
+        let cli = parse_cli(&[
+            "--server-uri",
+            "https://cli.example",
+            "--api-key",
+            "/cli/api-key",
+            "--policy-id",
+            "cli-policy",
+            "--cert-path",
+            "/cli/root.pem",
+            "--max-retries",
+            "9",
+            "--retry-min-backoff-secs",
+            "4",
+            "--retry-max-backoff-secs",
+            "40",
+        ]);
+        let cfg: Config = toml::from_str(
+            r#"
+server_uri = "https://config.example"
+api_key = "/config/api-key"
+policy_id = "config-policy"
+cert_path = "/config/root.pem"
+max_retries = 2
+retry_min_backoff_secs = 1
+retry_max_backoff_secs = 10
+"#,
+        )
+        .unwrap();
+
+        let settings = CertifySettings::resolve(&cli, &cfg).unwrap();
+
+        assert_eq!(settings.server_uri, "https://cli.example");
+        assert_eq!(settings.api_key_path, PathBuf::from("/cli/api-key"));
+        assert_eq!(settings.policy_domain, "cli-policy");
+        assert_eq!(settings.cert_path, PathBuf::from("/cli/root.pem"));
+        assert_eq!(settings.retry_config.max_retries, 9);
+        assert_eq!(settings.retry_config.min_backoff_secs, 4);
+        assert_eq!(settings.retry_config.max_backoff_secs, 40);
+    }
+
+    #[test]
+    fn certify_settings_use_config_and_builtin_defaults() {
+        let cli = parse_cli(&[]);
+        let cfg: Config = toml::from_str(
+            r#"
+server_uri = "http://config.example"
+policy_id = "config-policy"
+"#,
+        )
+        .unwrap();
+
+        let settings = CertifySettings::resolve(&cli, &cfg).unwrap();
+
+        assert_eq!(settings.server_uri, "http://config.example");
+        assert_eq!(
+            settings.api_key_path,
+            PathBuf::from("/etc/tas_agent/api-key")
+        );
+        assert_eq!(settings.policy_domain, "config-policy");
+        assert_eq!(
+            settings.cert_path,
+            PathBuf::from("/etc/tas_agent/root_cert.pem")
+        );
+        assert_eq!(settings.retry_config.max_retries, 3);
+        assert_eq!(settings.retry_config.min_backoff_secs, 1);
+        assert_eq!(settings.retry_config.max_backoff_secs, 30);
+    }
+
+    #[test]
+    fn certify_settings_validate_required_values() {
+        let missing_server = CertifySettings::resolve(&parse_cli(&[]), &Config::default())
+            .err()
+            .unwrap();
+        assert_eq!(missing_server.to_string(), "server URI is required");
+
+        let malformed_server = CertifySettings::resolve(
+            &parse_cli(&["--server-uri", "config.example", "--policy-id", "policy"]),
+            &Config::default(),
+        )
+        .err()
+        .unwrap();
+        assert!(malformed_server
+            .to_string()
+            .contains("server URI must start with http:// or https://"));
+
+        let missing_policy = CertifySettings::resolve(
+            &parse_cli(&["--server-uri", "https://config.example"]),
+            &Config::default(),
+        )
+        .err()
+        .unwrap();
+        assert_eq!(
+            missing_policy.to_string(),
+            "policy-domain is required for certify flow"
+        );
+    }
+
+    #[test]
+    fn cpu_only_report_data_uses_plain_binding() {
+        let nonce = "0123456789abcdef";
+        let public_key = b"public-key";
+
+        let actual = certify_report_data(nonce, public_key, &[]);
+        let expected = compute_report_data_binding(nonce.as_bytes(), public_key);
+
+        assert_eq!(actual, expected);
+        assert_eq!(actual.len(), 64);
+    }
+
+    #[cfg(feature = "gpu-nvidia")]
+    #[test]
+    fn gpu_report_data_uses_component_hash_order() {
+        let nonce = "0123456789abcdef";
+        let public_key = b"public-key";
+        let mut hashes = vec![1_u8; 64];
+        hashes.extend(vec![2_u8; 64]);
+
+        let actual = certify_report_data(nonce, public_key, &hashes);
+        let expected =
+            compute_report_data_binding_with_components(nonce.as_bytes(), public_key, &hashes);
+
+        assert_eq!(actual, expected);
+        assert_eq!(actual.len(), 64);
+
+        let mut reversed = hashes.clone();
+        reversed.reverse();
+        assert_ne!(actual, certify_report_data(nonce, public_key, &reversed));
+    }
+
+    #[cfg(feature = "gpu-nvidia")]
+    #[test]
+    fn certify_settings_resolve_gpu_enablement() {
+        for (cli_disabled, config_disabled, expected_enabled) in [
+            (false, false, true),
+            (true, false, false),
+            (false, true, false),
+            (true, true, false),
+        ] {
+            let mut args = vec![
+                "--server-uri",
+                "https://config.example",
+                "--policy-id",
+                "policy",
+            ];
+            if cli_disabled {
+                args.push("--no-gpu");
+            }
+            let cli = parse_cli(&args);
+            let cfg = Config {
+                no_gpu: Some(config_disabled),
+                ..Default::default()
+            };
+
+            let settings = CertifySettings::resolve(&cli, &cfg).unwrap();
+
+            assert_eq!(settings.gpu_enabled, expected_enabled);
+        }
+    }
 }


### PR DESCRIPTION
- Collect GPU evidence during certificate issuance and renewal, bind it to the CPU attestation report, and submit it to TAS. Previously, the certify flow did not collect GPU evidence.
- Add coverage for the certify feature and streamline CI by removing duplicate test runs. Cache and reuse the libnvat build across runs to reduce test execution time.